### PR TITLE
Feature/add speed multiplier

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,10 @@
 				"speedAttribute": {
 					"name": "Speed Attribute",
 					"hint": "The attribute that defines a token's walking speed. This is used during coloring of the measured path."
+				},
+				"speedMultiplier": {
+					"name": "Speed Multiplier",
+					"hint": "A speed multiplier for use in modifying base attribute speed when measuring paths."
 				}
 			},
 			"speeds": {

--- a/src/speed_provider.js
+++ b/src/speed_provider.js
@@ -1,5 +1,5 @@
 import {settingsKey} from "./settings.js"
-import {getDefaultDashMultiplier, getDefaultSpeedAttribute} from "./systems.js"
+import {getDefaultDashMultiplier, getDefaultSpeedAttribute, getDefaultSpeedMultiplier} from "./systems.js"
 
 /**
  * Base class for all speed providers.
@@ -122,9 +122,10 @@ export class GenericSpeedProvider extends SpeedProvider {
 
 	getRanges(token) {
 		const speedAttribute = this.getSetting("speedAttribute")
+		const speedMultiplier = this.getSetting("speedMultiplier")
 		if (!speedAttribute)
 			return []
-		const tokenSpeed = getProperty(token, speedAttribute)
+		const tokenSpeed = (speedMultiplier ? (getProperty(token, speedAttribute) * speedMultiplier) : (getProperty(token, speedAttribute))) 
 		if (tokenSpeed === undefined) {
 			console.warn(`Drag Ruler (Generic Speed Provider) | The configured token speed attribute "${speedAttribute}" didn't return a speed value. To use colors based on drag distance set the setting to the correct value (or clear the box to disable this feature).`)
 			return []
@@ -154,6 +155,15 @@ export class GenericSpeedProvider extends SpeedProvider {
 				config: true,
 				type: Number,
 				default: getDefaultDashMultiplier(),
+			},
+			{
+				id: "speedMultiplier",
+				name: "drag-ruler.genericSpeedProvider.settings.speedMultiplier.name",
+				hint: "drag-ruler.genericSpeedProvider.settings.speedMultiplier.hint",
+				scope: "world",
+				config: true,
+				type: Number,
+				default: getDefaultSpeedMultiplier(),
 			}
 		]
 	}

--- a/src/systems.js
+++ b/src/systems.js
@@ -7,16 +7,27 @@ export function getDefaultSpeedAttribute() {
 			return "actor.data.data.mech.speed"
 		case "pf1":
 			return "actor.data.data.attributes.speed.land.total"
+		case "cyberpunk-red-core":
+			return "actor.data.data.stats.move.value"
 	}
 	return ""
 }
 
 export function getDefaultDashMultiplier() {
 	switch (game.system.id) {
+		case "cyberpunk-red-core":
 		case "dnd5e":
 		case "lancer":
 		case "pf1":
 			return 2
 	}
 	return 0
+}
+
+export function getDefaultSpeedMultiplier() {
+	switch (game.system.id) {
+		case "cyberpunk-red-core":
+			return 2
+	}
+	return 1
 }


### PR DESCRIPTION
PR to add:
- "Speed Multiplier" setting with default value of 1, but value of 2 for cyberpunk-red-core game system.
- EN language text strings for new setting.
- Default setting values for cyberpunk-red-core game system.

Let me know what you think. Thanks!
![preview](https://user-images.githubusercontent.com/4825979/111224232-86f8ec80-85b4-11eb-848f-1f736b497c59.png)