### PR TITLE
Add cyberpunk-red-core system speed provider

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-import {GenericSpeedProvider, SpeedProvider} from "./speed_provider.js"
+import {GenericSpeedProvider, SpeedProvider, CyberpunkRedCoreSpeedProvider} from "./speed_provider.js"
 import {settingsKey} from "./settings.js"
 
 export const availableSpeedProviders = {}
@@ -67,6 +67,8 @@ export function updateSpeedProvider() {
 export function initApi() {
 	const genericSpeedProviderInstance = new GenericSpeedProvider("native")
 	setupProvider(genericSpeedProviderInstance)
+	const cprSpeedProviderInstance = new CyberpunkRedCoreSpeedProvider("system.cyberpunk-red-core")
+	setupProvider(cprSpeedProviderInstance)
 }
 
 export function getRangesFromSpeedProvider(token) {

--- a/src/speed_provider.js
+++ b/src/speed_provider.js
@@ -158,3 +158,50 @@ export class GenericSpeedProvider extends SpeedProvider {
 		]
 	}
 }
+
+export class CyberpunkRedCoreSpeedProvider extends SpeedProvider {
+	get colors() {
+		return [
+			{id: "walk", default: 0x00FF00, name: "drag-ruler.genericSpeedProvider.speeds.walk"},
+			{id: "dash", default: 0xFFFF00, name: "drag-ruler.genericSpeedProvider.speeds.dash"}
+		]
+	}
+
+	getRanges(token) {
+		const speedAttribute = this.getSetting("speedAttribute")
+		if (!speedAttribute)
+			return []
+		const tokenSpeed = getProperty(token, speedAttribute) * 2
+		if (tokenSpeed === undefined) {
+			console.warn(`Drag Ruler (CyberpunkRedCore Speed Provider) | The configured token speed attribute "${speedAttribute}" didn't return a speed value. To use colors based on drag distance set the setting to the correct value (or clear the box to disable this feature).`)
+			return []
+		}
+		const dashMultiplier = this.getSetting("dashMultiplier")
+		if (!dashMultiplier)
+			return [{range: tokenSpeed, color: "walk"}]
+		return [{range: tokenSpeed, color: "walk"}, {range: tokenSpeed * dashMultiplier, color: "dash"}]
+	}
+
+	get settings() {
+		return [
+			{
+				id: "speedAttribute",
+				name: "drag-ruler.genericSpeedProvider.settings.speedAttribute.name",
+				hint: "drag-ruler.genericSpeedProvider.settings.speedAttribute.hint",
+				scope: "world",
+				config: true,
+				type: String,
+				default: getDefaultSpeedAttribute(),
+			},
+			{
+				id: "dashMultiplier",
+				name: "drag-ruler.genericSpeedProvider.settings.dashMultiplier.name",
+				hint: "drag-ruler.genericSpeedProvider.settings.dashMultiplier.hint",
+				scope: "world",
+				config: true,
+				type: Number,
+				default: getDefaultDashMultiplier(),
+			}
+		]
+	}
+}

--- a/src/systems.js
+++ b/src/systems.js
@@ -7,12 +7,15 @@ export function getDefaultSpeedAttribute() {
 			return "actor.data.data.mech.speed"
 		case "pf1":
 			return "actor.data.data.attributes.speed.land.total"
+		case "cyberpunk-red-core":
+			return "actor.data.data.stats.move.value"
 	}
 	return ""
 }
 
 export function getDefaultDashMultiplier() {
 	switch (game.system.id) {
+		case "cyberpunk-red-core":
 		case "dnd5e":
 		case "lancer":
 		case "pf1":


### PR DESCRIPTION
The goal of this PR is to add a a SpeedProvider for the CyberpunkRED-Core system (https://gitlab.com/JasonAlanTerry/fvtt-cyberpunk-red-core).

Current known issues that I could use help with:
1. The SpeedProvider is not selected as default when freshly added to a CyberpunkRED-Core world.
2. The colors are not automatically set for Walk/Dash/Inaccessible. I missed where those could be added.

Thanks!