### PR TITLE
libWrapper compatibility

### DIFF
--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -1,0 +1,49 @@
+// Hooks using libWrapper
+import { onTokenLeftDragStart,
+         onTokenLeftDragMove,
+         onTokenDragLeftDrop,
+         onTokenDragLeftCancel,
+         handleKeys } from "./main.js";
+
+const MODULE_ID = "drag-ruler";
+
+export function registerLibWrapper() {
+  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftStart", onTokenLeftDragStartWrap, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftMove", onDragLeftMoveWrap, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftDrop", onDragLeftDropWrap, "MIXED");
+  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftCancel", onDragLeftCancelWrap, "MIXED");
+
+  libWrapper.register(MODULE_ID, "KeyboardManager.prototype._handleKeys", handleKeysWrap, "MIXED");
+}
+
+// simple wraps to keep the original functionality when not using libWrapper
+function onTokenLeftDragStartWrap(wrapped, event) {
+  wrapped(event);
+  onTokenLeftDragStart.call(this, event);
+}
+
+function onDragLeftMoveWrap(wrapped, event) {
+  wrapped(event);
+  onTokenLeftDragMove.call(this, event);
+}
+
+function onDragLeftDropWrap(wrapped, event) {
+  const eventHandled = onTokenDragLeftDrop.call(this, event);
+  if(!eventHandled) {
+    wrapped(event);
+  }
+}
+
+function onDragLeftCancelWrap(wrapped, event) {
+  const eventHandled = onTokenDragLeftCancel.call(this, event);
+  if(!eventHandled) {
+    wrapped(event);
+  }
+}
+
+function handleKeysWrap(wrapped, event, key, up) {
+  const eventHandled = handleKeys.call(this, event, key, up);
+  if(!eventHandled) {
+    wrapped(event, key, up);
+  }
+}

--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -1,8 +1,8 @@
 // Hooks using libWrapper
-import { onTokenLeftDragStart,
-         onTokenLeftDragMove,
-         onTokenDragLeftDrop,
-         onTokenDragLeftCancel,
+import { onEntityLeftDragStart,
+         onEntityLeftDragMove,
+         onEntityDragLeftDrop,
+         onEntityDragLeftCancel,
          handleKeys } from "./main.js";
 
 const MODULE_ID = "drag-ruler";
@@ -19,23 +19,23 @@ export function registerLibWrapper() {
 // simple wraps to keep the original functionality when not using libWrapper
 function onTokenLeftDragStartWrap(wrapped, event) {
   wrapped(event);
-  onTokenLeftDragStart.call(this, event);
+  onEntityLeftDragStart.call(this, event);
 }
 
 function onDragLeftMoveWrap(wrapped, event) {
   wrapped(event);
-  onTokenLeftDragMove.call(this, event);
+  onEntityLeftDragMove.call(this, event);
 }
 
 function onDragLeftDropWrap(wrapped, event) {
-  const eventHandled = onTokenDragLeftDrop.call(this, event);
+  const eventHandled = onEntityDragLeftDrop.call(this, event);
   if(!eventHandled) {
     wrapped(event);
   }
 }
 
 function onDragLeftCancelWrap(wrapped, event) {
-  const eventHandled = onTokenDragLeftCancel.call(this, event);
+  const eventHandled = onEntityDragLeftCancel.call(this, event);
   if(!eventHandled) {
     wrapped(event);
   }

--- a/src/main.js
+++ b/src/main.js
@@ -9,12 +9,18 @@ import {getMovementHistory, resetMovementHistory} from "./movement_tracking.js";
 import {registerSettings, settingsKey} from "./settings.js"
 import {recalculate} from "./socket.js";
 import {SpeedProvider} from "./speed_provider.js"
+import {registerLibWrapper} from "./libwrapper.js"
 
 Hooks.once("init", () => {
 	registerSettings()
 	initApi()
-	hookTokenDragHandlers()
-	hookKeyboardManagerFunctions()
+
+        if(!game.modules.get('lib-wrapper')?.active) {
+	  hookTokenDragHandlers()
+	  hookKeyboardManagerFunctions()
+        } else {
+          registerLibWrapper();
+        }
 
 	Ruler = DragRulerRuler;
 
@@ -91,7 +97,7 @@ function hookKeyboardManagerFunctions() {
 	}
 }
 
-function handleKeys(event, key, up) {
+export function handleKeys(event, key, up) {
 	if (event.repeat || this.hasFocus)
 		return false
 
@@ -122,7 +128,7 @@ function onKeyShift(up) {
 	ruler.measure(measurePosition, {snap: up})
 }
 
-function onTokenLeftDragStart(event) {
+export function onTokenLeftDragStart(event) {
 	if (!currentSpeedProvider.usesRuler(this))
 		return
 	const ruler = canvas.controls.ruler
@@ -140,13 +146,13 @@ function onTokenLeftDragStart(event) {
 	ruler.dragRulerAddWaypoint(tokenCenter, false);
 }
 
-function onTokenLeftDragMove(event) {
+export function onTokenLeftDragMove(event) {
 	const ruler = canvas.controls.ruler
 	if (ruler.isDragRuler)
 		onMouseMove.call(ruler, event)
 }
 
-function onTokenDragLeftDrop(event) {
+export function onTokenDragLeftDrop(event) {
 	const ruler = canvas.controls.ruler
 	if (!ruler.isDragRuler)
 		return false
@@ -157,7 +163,7 @@ function onTokenDragLeftDrop(event) {
 	return true
 }
 
-function onTokenDragLeftCancel(event) {
+export function onTokenDragLeftCancel(event) {
 	// This function is invoked by right clicking
 	const ruler = canvas.controls.ruler
 	if (!ruler.isDragRuler || ruler._state === Ruler.STATES.MOVING)

--- a/src/main.js
+++ b/src/main.js
@@ -118,7 +118,7 @@ function hookLayerFunctions() {
 	}
 }
 
-function handleKeys(event, key, up) {
+export function handleKeys(event, key, up) {
 	if (event.repeat || this.hasFocus)
 		return false
 
@@ -185,7 +185,7 @@ function onKeyEscape(up) {
 	return true;
 }
 
-function onEntityLeftDragStart(event) {
+export function onEntityLeftDragStart(event) {
 	const isToken = this instanceof Token;
 	const ruler = canvas.controls.ruler
 	ruler.draggedEntity = this;
@@ -202,7 +202,7 @@ function onEntityLeftDragStart(event) {
 	}
 }
 
-function startDragRuler(options, measureImmediately=true) {
+export function startDragRuler(options, measureImmediately=true) {
 	const isToken = this instanceof Token;
 	if (isToken && !currentSpeedProvider.usesRuler(this))
 		return;
@@ -223,13 +223,13 @@ function startDragRuler(options, measureImmediately=true) {
 		ruler.measure(destination, options);
 }
 
-function onEntityLeftDragMove(event) {
+export function onEntityLeftDragMove(event) {
 	const ruler = canvas.controls.ruler
 	if (ruler.isDragRuler)
 		onMouseMove.call(ruler, event)
 }
 
-function onEntityDragLeftDrop(event) {
+export function onEntityDragLeftDrop(event) {
 	const ruler = canvas.controls.ruler
 	if (!ruler.isDragRuler) {
 		ruler.draggedEntity = undefined;
@@ -246,7 +246,7 @@ function onEntityDragLeftDrop(event) {
 	return true
 }
 
-function onEntityDragLeftCancel(event) {
+export function onEntityDragLeftCancel(event) {
 	// This function is invoked by right clicking
 	const ruler = canvas.controls.ruler
 	if (!ruler.draggedEntity || ruler._state === Ruler.STATES.MOVING)

--- a/src/main.js
+++ b/src/main.js
@@ -15,13 +15,11 @@ import {registerLibWrapper} from "./libwrapper.js"
 Hooks.once("init", () => {
 	registerSettings()
 	initApi()
-	hookDragHandlers(Token);
-	hookDragHandlers(MeasuredTemplate);
-	hookKeyboardManagerFunctions()
 	hookLayerFunctions();
 
         if(!game.modules.get('lib-wrapper')?.active) {
-	  hookTokenDragHandlers()
+	  hookDragHandlers(Token)
+          hookDragHandlers(MeasuredTemplate);
 	  hookKeyboardManagerFunctions()
         } else {
           registerLibWrapper();


### PR DESCRIPTION
Hi! This merge request adds basic libWrapper compatibility. I set this up so that from the user perspective, libWrapper is completely optional. If and only if libWrapper is installed, it will wrap:

- Token.prototype._onDragLeftStart
- Token.prototype._onDragLeftMove
- Token.prototype._onDragLeftDrop
- Token.prototype._onDragLeftCancel
- KeyboardManager.prototype._handleKeys
- TokenLayer.prototype.undoHistory

This should help with compatibility with other modules. Personally, my interest is that this sets up a bigger shift to using libWrapper and libRuler. Tested and appears to be working both with and without libWrapper.