### PR TITLE
Basic libRuler compatibility

### DIFF
--- a/src/foundry_imports.js
+++ b/src/foundry_imports.js
@@ -100,7 +100,7 @@ async function animateEntities(entities, draggedEntity, draggedRays, wasPaused) 
 		trackRays(entities, entityAnimationData.map(({rays}) => rays)).then(() => recalculate(entities));
 }
 
-function calculateEntityOffset(entityA, entityB) {
+export function calculateEntityOffset(entityA, entityB) {
 	return {x: entityA.data.x - entityB.data.x, y: entityA.data.y - entityB.data.y};
 }
 

--- a/src/foundry_imports.js
+++ b/src/foundry_imports.js
@@ -104,7 +104,7 @@ export function calculateEntityOffset(entityA, entityB) {
 	return {x: entityA.data.x - entityB.data.x, y: entityA.data.y - entityB.data.y};
 }
 
-function applyOffsetToRay(ray, offset) {
+export function applyOffsetToRay(ray, offset) {
 	const newRay = new Ray({x: ray.A.x + offset.x, y: ray.A.y + offset.y}, {x: ray.B.x + offset.x, y: ray.B.y + offset.y});
 	newRay.isPrevious = ray.isPrevious;
 	return newRay;

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -1,32 +1,31 @@
-import { MODULE_ID } from "./libwrapper.js"
+import {settingsKey} from "./settings.js"
 import { applyTokenSizeOffset, getTokenShape, getSnapPointForToken, setSnapParameterOnOptions } from "./util.js";
 
 export function registerLibRuler() {
   // Wrappers for base Ruler methods
-  libWrapper.register(MODULE_ID, "Ruler.prototype.clear", dragRulerClear, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Ruler.prototype.update", dragRulerUpdate, "MIXED");
-  libWrapper.register(MODULE_ID, "Ruler.prototype._endMeasurement", dragRulerEndMeasurement, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Ruler.prototype._getMovementToken", dragRulerGetMovementToken, "MIXED");
-  libWrapper.register(MODULE_ID, "Ruler.prototype.moveToken", dragRulerMoveToken, "MIXED");
+  libWrapper.register(settingsKey, "Ruler.prototype.clear", dragRulerClear, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype.update", dragRulerUpdate, "MIXED");
+  libWrapper.register(settingsKey, "Ruler.prototype._endMeasurement", dragRulerEndMeasurement, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype._getMovementToken", dragRulerGetMovementToken, "MIXED");
+  libWrapper.register(settingsKey, "Ruler.prototype.moveToken", dragRulerMoveToken, "MIXED");
 
   // Wrappers for libRuler Ruler methods
-  libWrapper.register(MODULE_ID, "Ruler.prototype.setDestination", dragRulerSetDestination, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Ruler.prototype._addWaypoint", dragRulerAddWaypoint, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype.setDestination", dragRulerSetDestination, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype._addWaypoint", dragRulerAddWaypoint, "WRAPPER");
 
   // Wrappers for libRuler RulerSegment methods
-  libWrapper.register(MODULE_ID, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");
-  libWrapper.register(MODULE_ID, "window.libRuler.RulerSegment.prototype.drawLine", dragRulerDrawLine, "MIXED");
-  libWrapper.register(MODULE_ID, "window.libRuler.RulerSegment.prototype.highlightPosition", dragRulerHighlightPosition, "MIXED");
+  libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");
+  libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.drawLine", dragRulerDrawLine, "MIXED");
+  libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.highlightPosition", dragRulerHighlightPosition, "MIXED");
 
   // Wrappers for event handlers for testing
   // see what is happening with the various events
-  libWrapper.register(MODULE_ID, "Ruler.prototype._onDragStart", dragRulerOnDragStart, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Ruler.prototype._onClickLeft", dragRulerOnClickLeft, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Ruler.prototype._onClickRight", dragRulerOnClickRight, "WRAPPER");
-  //libWrapper.register(MODULE_ID, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Ruler.prototype._onMouseUp", dragRulerOnMouseUp, "WRAPPER");
-  libWrapper.register(MODULE_ID, "KeyboardManager.prototype._onSpace", dragRulerOnSpace, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype._onDragStart", dragRulerOnDragStart, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype._onClickLeft", dragRulerOnClickLeft, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype._onClickRight", dragRulerOnClickRight, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype._onMouseUp", dragRulerOnMouseUp, "WRAPPER");
+  libWrapper.register(settingsKey, "KeyboardManager.prototype._onSpace", dragRulerOnSpace, "WRAPPER");
 
   addRulerProperties();
 }
@@ -67,7 +66,7 @@ function dragRulerOnSpace(wrapper, up, modifiers) {
 
 export function log(...args) {
   try {
-      console.log(MODULE_ID, '|', ...args);
+      console.log(settingsKey, '|', ...args);
   } catch (e) {}
 }
 
@@ -79,11 +78,11 @@ export function log(...args) {
  * Wrap for Ruler.clear
  */
 function dragRulerClear(wrapped) {
-  //this.setFlag(MODULE_ID, "previousWaypoints", []);
-  //const previousLabels = this.getFlag(MODULE_ID, "previousLabels");
+  //this.setFlag(settingsKey, "previousWaypoints", []);
+  //const previousLabels = this.getFlag(settingsKey, "previousLabels");
   //previousLabels.removeChildren().forEach(c => c.destroy());
-  //this.unsetFlag(MODULE_ID, "previousLabels");
-  //this.unsetFlag(MODULE_ID, "dragRulerRanges");
+  //this.unsetFlag(settingsKey, "previousLabels");
+  //this.unsetFlag(settingsKey, "dragRulerRanges");
   log("Clear.");
   wrapped();
 }
@@ -106,7 +105,7 @@ function dragRulerUpdate(wrapped, data) {
 function dragRulerEndMeasurement(wrapped) {
   log("EndMeasurement");
   wrapped();
-  this.unsetFlag(MODULE_ID, "draggedTokenID");
+  this.unsetFlag(settingsKey, "draggedTokenID");
 }
 
 
@@ -121,7 +120,7 @@ function dragRulerOnMouseMove(wrapped, event) {
   log("dragRulerOnMouseMove");
   if(!this.isDragRuler) return wrapped(event);
 
-  const offset = this.getFlag(MODULE_ID, "rulerOffset");
+  const offset = this.getFlag(settingsKey, "rulerOffset");
   event.data.destination.x = event.data.destination.x + offset.x;
   event.data.destination.y = event.data.destination.y + offset.y;
 
@@ -137,7 +136,7 @@ function dragRulerOnMouseMove(wrapped, event) {
  */
 function dragRulerSetDestination(wrapped, destination) {
   log("dragRulerSetDestination");
-  const snap = this.getFlag(MODULE_ID, "snap");
+  const snap = this.getFlag(settingsKey, "snap");
   if(snap) {
     const new_dest = getSnapPointForToken(destination.x, destination.y, this.draggedToken);
     destination.x = new_dest.x;
@@ -160,7 +159,7 @@ function dragRulerSetDestination(wrapped, destination) {
 async function dragRulerMoveToken(wrapped) {
   log(`dragRulerMoveToken`, event, this);
   if(!this.isDragRuler) return wrapped(event);
-  if(this.getFlag(MODULE_ID, "doTokenMove")) {
+  if(this.getFlag(settingsKey, "doTokenMove")) {
 		let options = {};
 		setSnapParameterOnOptions(this, options);
 
@@ -170,7 +169,7 @@ async function dragRulerMoveToken(wrapped) {
 			this.dragRulerDeleteWaypoint(event, options);
 		}
   } else {
-    this.setFlag(MODULE_ID, "doTokenMove", false);
+    this.setFlag(settingsKey, "doTokenMove", false);
     return wrapped(event);
   }
 }
@@ -224,7 +223,7 @@ function dragRulerDeleteWaypoint(event={preventDefault: () => {return}}, options
 	if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
 		event.preventDefault();
 		const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
-		const rulerOffset = this.getFlag(MODULE_ID, "rulerOffset");
+		const rulerOffset = this.getFlag(settingsKey, "rulerOffset");
 		this._removeWaypoint({x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y});
 		game.user.broadcastActivity({ruler: this});
 	}
@@ -367,14 +366,14 @@ function addRulerProperties() {
   log(`addRulerProperties`);
 	// Add a getter method to check for drag token in Ruler flags.
 	Object.defineProperty(Ruler.prototype, "isDragRuler", {
-		get() { return Boolean(this.getFlag(MODULE_ID, "draggedTokenID")); },
+		get() { return Boolean(this.getFlag(settingsKey, "draggedTokenID")); },
 		configurable: true
 	});
 
 	// Add a getter method to return the token for the stored token id
 	Object.defineProperty(Ruler.prototype, "draggedToken", {
 		get() {
-			const draggedTokenID = this.getFlag(MODULE_ID, "draggedTokenID");
+			const draggedTokenID = this.getFlag(settingsKey, "draggedTokenID");
 			if(!draggedTokenID) return undefined;
 			return canvas.tokens.get(draggedTokenID);
 		},

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -30,7 +30,6 @@ export function registerLibRuler() {
 
   // Wrappers for libRuler RulerSegment methods
   libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");
-  libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.drawLine", dragRulerDrawLine, "MIXED");
   libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.highlightPosition", dragRulerHighlightPosition, "MIXED");
 
   addRulerProperties();
@@ -264,6 +263,11 @@ function dragRulerAddProperties(wrapped) {
   this.ray.dragRulerVisitedSpaces = origin.dragRulerVisitedSpaces;
   this.ray.dragRulerFinalState = origin.dragRulerFinalState;
 
+  // set opacity for drawing the line and the highlight
+  const opacity_mult = this.ray.isPrevious ? 0.33 : 1;
+  this.opacityMultipliers.line = opacity_mult;
+  this.opacityMultipliers.highlight = opacity_mult;
+
   // TO-DO: Is there any need to store the original ray? What about when drawing lines (see original drag ruler measure function)
 }
 
@@ -288,19 +292,6 @@ function dragRulerHighlightPosition(wrapped, position) {
 	}
 
 }
-
-function dragRulerDrawLine(wrapped) {
-  log(`dragRulerDrawLine`);
-  if(!this.ruler.isDragRuler) return wrapped();
-  const opacityMultiplier = this.ray.isPrevious ? 0.33 : 1;
-  const ray = this.ray;
-  const r = this.ruler.ruler;
-  const rulerColor = this.color;
-
-  r.lineStyle(6, 0x000000, 0.5 * opacityMultiplier).moveTo(ray.A.x, ray.A.y).lineTo(ray.B.x, ray.B.y).
-    lineStyle(4, rulerColor, 0.25 * opacityMultiplier).moveTo(ray.A.x, ray.A.y).lineTo(ray.B.x, ray.B.y);
-}
-
 
 
 // Additions to Ruler class

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -19,55 +19,13 @@ export function registerLibRuler() {
   libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.drawLine", dragRulerDrawLine, "MIXED");
   libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.highlightPosition", dragRulerHighlightPosition, "MIXED");
 
-  // Wrappers for event handlers for testing
-  // see what is happening with the various events
-  libWrapper.register(settingsKey, "Ruler.prototype._onDragStart", dragRulerOnDragStart, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype._onClickLeft", dragRulerOnClickLeft, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype._onClickRight", dragRulerOnClickRight, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype._onMouseUp", dragRulerOnMouseUp, "WRAPPER");
-  libWrapper.register(settingsKey, "KeyboardManager.prototype._onSpace", dragRulerOnSpace, "WRAPPER");
-
   addRulerProperties();
 
   // tell libWrapper that it can ignore the conflict warning from drag ruler not always calling
-  // the underlying method for Ruler.moveToken. (i.e., drag ruler interrupts it 
+  // the underlying method for Ruler.moveToken. (i.e., drag ruler interrupts it
   // if just adding or deleting a waypoint)
   libWrapper.ignore_conflicts(settingsKey, "libruler", "Ruler.prototype.moveToken");
 
-}
-
-// Wrappers for event handlers for testing
-function dragRulerOnDragStart(wrapped, event) {
-  log(`Ruler._onDragStart`, event);
-  wrapped(event);
-}
-
-function dragRulerOnClickLeft(wrapped, event) {
-  log(`Ruler._onClickLeft`, event);
-  wrapped(event);
-}
-
-function dragRulerOnClickRight(wrapped, event) {
-  log(`Ruler._onClickRight`, event);
-  wrapped(event);
-}
-
-/*
- * Defined below
-function dragRulerOnMouseMove(wrapper, event) {
-  log(`Ruler._onMouseMove`, event);
-  wrapper(event);
-}
-*/
-
-function dragRulerOnMouseUp(wrapped, event) {
-  log(`Ruler._onMouseUp`, event);
-  wrapped(event);
-}
-
-function dragRulerOnSpace(wrapped, event, up, modifiers) {
-  log(`Keyboard._onSpace. up: ${up}`);
-  return wrapped(event, up, modifiers);
 }
 
 export function log(...args) {
@@ -180,7 +138,7 @@ async function dragRulerMoveToken(wrapped) {
       log(`Deleting waypoint`);
       this.dragRulerDeleteWaypoint(event, options);
     }
-  } 
+  }
 }
 
 /*

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -54,7 +54,7 @@ function dragRulerClear(wrapped) {
  */
 function dragRulerUpdate(wrapped, data) {
   if(this.draggedEntity && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
-			return;
+      return;
 
   wrapped(data);
 }
@@ -100,13 +100,13 @@ function dragRulerOnMouseMove(wrapped, event) {
  */
 function dragRulerDeferMeasurement(wrapped, destination, event) {
   if(this.isDragRuler) {
-		this.deferredMeasurementData = {destination, event};
-		if (!this.deferredMeasurementTimeout) {
-			this.deferredMeasurementPromise = new Promise((resolve, reject) => this.deferredMeasurementResolve = resolve);
-			this.deferredMeasurementTimeout = window.setTimeout(() => this.scheduleMeasurement(this.deferredMeasurementData.destination, this.deferredMeasurementData.event));
-		}
-	}
-	return wrapped(destination, event);
+    this.deferredMeasurementData = {destination, event};
+    if (!this.deferredMeasurementTimeout) {
+      this.deferredMeasurementPromise = new Promise((resolve, reject) => this.deferredMeasurementResolve = resolve);
+      this.deferredMeasurementTimeout = window.setTimeout(() => this.scheduleMeasurement(this.deferredMeasurementData.destination, this.deferredMeasurementData.event));
+    }
+  }
+  return wrapped(destination, event);
 }
 
 /*
@@ -130,7 +130,7 @@ async function dragRulerDoDeferredMeasurements() {
 /*
  * Modify destination to be the snap point for the token when snap is set.
  * Wrap for Ruler.setDestination from libRuler.
- * @param {Object} wrapped 	Wrapped function from libWrapper.
+ * @param {Object} wrapped  Wrapped function from libWrapper.
  * @param {Object} destination  The destination point to which to measure. Should have at least x and y properties.
  */
 function dragRulerSetDestination(wrapped, destination) {
@@ -185,14 +185,14 @@ function dragRulerAddWaypoint(wrapped, point, center = true) {
 
 
 export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
-		if ( destination )
-			waypoints = waypoints.concat([destination]);
-		return waypoints.slice(1).map((wp, i) => {
-			const ray =  new Ray(waypoints[i], wp);
-			ray.isPrevious = Boolean(waypoints[i].isPrevious);
-			return ray;
-		});
-	}
+    if ( destination )
+      waypoints = waypoints.concat([destination]);
+    return waypoints.slice(1).map((wp, i) => {
+      const ray =  new Ray(waypoints[i], wp);
+      ray.isPrevious = Boolean(waypoints[i].isPrevious);
+      return ray;
+    });
+  }
 
 
 /*
@@ -238,57 +238,57 @@ function dragRulerAddProperties(wrapped) {
 // Additions to Ruler class
 function addRulerProperties() {
   log(`addRulerProperties`);
-	// Add a getter method to check for drag token in Ruler flags.
-	Object.defineProperty(Ruler.prototype, "isDragRuler", {
-		get() { return Boolean(this.getFlag(settingsKey, "draggedEntityID")); },
-		configurable: true
-	});
+  // Add a getter method to check for drag token in Ruler flags.
+  Object.defineProperty(Ruler.prototype, "isDragRuler", {
+    get() { return Boolean(this.getFlag(settingsKey, "draggedEntityID")); },
+    configurable: true
+  });
 
-	// Add a getter method to return the token for the stored token id
-	Object.defineProperty(Ruler.prototype, "draggedEntity", {
-		get() {
-			const draggedEntityID = this.getFlag(settingsKey, "draggedEntityID");
-			if(!draggedEntityID) return undefined;
-			return canvas.tokens.get(draggedEntityID);
-		},
-		configurable: true
-	});
+  // Add a getter method to return the token for the stored token id
+  Object.defineProperty(Ruler.prototype, "draggedEntity", {
+    get() {
+      const draggedEntityID = this.getFlag(settingsKey, "draggedEntityID");
+      if(!draggedEntityID) return undefined;
+      return canvas.tokens.get(draggedEntityID);
+    },
+    configurable: true
+  });
 
-	Object.defineProperty(Ruler.prototype, "dragRulerAddWaypointHistory", {
+  Object.defineProperty(Ruler.prototype, "dragRulerAddWaypointHistory", {
     value: dragRulerAddWaypointHistory,
     writable: true,
     configurable: true
-	});
+  });
 
-	Object.defineProperty(Ruler.prototype, "dragRulerClearWaypoints", {
-	  value: dragRulerClearWaypoints,
-	  writable: true,
-	  configurable: true
-	});
+  Object.defineProperty(Ruler.prototype, "dragRulerClearWaypoints", {
+    value: dragRulerClearWaypoints,
+    writable: true,
+    configurable: true
+  });
 
-	Object.defineProperty(Ruler.prototype, "dragRulerDeleteWaypoint", {
-	  value: dragRulerDeleteWaypoint,
-	  writable: true,
-	  configurable: true
-	});
+  Object.defineProperty(Ruler.prototype, "dragRulerDeleteWaypoint", {
+    value: dragRulerDeleteWaypoint,
+    writable: true,
+    configurable: true
+  });
 
-	Object.defineProperty(Ruler.prototype, "dragRulerAbortDrag", {
-	  value: dragRulerAbortDrag,
-	  writable: true,
-	  configurable: true
-	});
+  Object.defineProperty(Ruler.prototype, "dragRulerAbortDrag", {
+    value: dragRulerAbortDrag,
+    writable: true,
+    configurable: true
+  });
 
-	Object.defineProperty(Ruler.prototype, "dragRulerRecalculate", {
-	  value: dragRulerRecalculate,
-	  writable: true,
-	  configurable: true
-	});
+  Object.defineProperty(Ruler.prototype, "dragRulerRecalculate", {
+    value: dragRulerRecalculate,
+    writable: true,
+    configurable: true
+  });
 
   Object.defineProperty(Ruler, "dragRulerGetRaysFromWaypoints", {
-	  value: dragRulerGetRaysFromWaypoints,
-	  writable: true,
-	  configurable: true
-	});
+    value: dragRulerGetRaysFromWaypoints,
+    writable: true,
+    configurable: true
+  });
 }
 
 

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -240,37 +240,29 @@ async function dragRulerAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
   const animate = isToken && !game.keyboard.isDown("Alt");
   selectedEntities = selectedEntities.filter(e => e.id !== token.id); // pull out the dragged token.
 
-  console.log(`drag-ruler|${animate ? "animating" : "not animating"} ${selectedEntities.length} selected tokens`, token, selectedEntities)
-  /*
-  let t_top_left = canvas.grid.getTopLeft(token.data.x, token.data.y);
-	const entityAnimationData = selectedEntities.map(entity => {
-		const entityOffset = calculateEntityOffset(entity, token);
-		const offsetRay = applyOffsetToRay(ray, entityOffset)
+  console.log(`drag-ruler|${animate ? "animating" : "not animating"} ${selectedEntities.length} selected tokens with dx, dy ${dx}, ${dy}`, token, selectedEntities)
 
-		return {entity, ray: offsetRay, entityOffset};
-	});
-
-	// probably don't want to do this b/c (1) need path from the wrapped function and (2) wrapped function has an update
+	// probably don't want to do the following b/c (1) need path from the wrapped function and (2) wrapped function already does the update
 	// await draggedEntity.scene.updateEmbeddedDocuments(draggedEntity.constructor.embeddedName, updates, {animate});
-  */
-  // animate the selected additional tokens
-  // don't use forEach b/c it does not play nicely with async
+
+  // animate the selected additional tokens using promises so they move as a group.
   const promises = [];
   for(const entity of selectedEntities) {
     //const top_left = canvas.grid.getTopLeft(entity.center.x, entity.center.y);
     const offset = { x: entity.center.x - token.center.x, y: entity.center.y - token.center.y };
-    console.log(`drag-ruler|Animating entity ${entity.name} at ${entity.center.x}, ${entity.center.y}. Token ${token.name} at ${token.center.x}, ${token.center.y}. Offset ${offset.x}, ${offset.y}`, entity, ray);
-    //wrapped(entity, ray, dx, dy, segment_num);
-    //wrapped(entity, ray, dx + entityOffset.x, dy + entityOffset.y, segment_num);
     const offsetRay = new Ray(ray.A, { x: ray.B.x + offset.x, y: ray.B.y + offset.y });
-    // don't await b/c this makes the tokens all move one-by-one
+    console.log(`drag-ruler|Animating entity ${entity.name} from ${entity.center.x}, ${entity.center.y} to ${offsetRay.B.x}, ${offsetRay.B.y}. Token ${token.name} at ${token.center.x}, ${token.center.y}. Offset ${offset.x}, ${offset.y}`);
+
+    // don't await here b/c this makes the tokens all move one-by-one
     promises.push(wrapped(entity, offsetRay, dx, dy, segment_num)); // usually works, but can occassionally fail to keep multiple tokens in original arrangement
     //promises.push(wrapped(entity, ray, dx + offset.x, dy + offset.y, segment_num)); // Fails to keep tokens in original arrangement much of the time
   }
-  // await to avoid confusing move errors if moving repeatedly very quickly
+
+  // use Promise.all to await to avoid confusing move errors if moving repeatedly very quickly
+  console.log(`drag-ruler|Animating ${token.name} from ${token.center.x}, ${token.center.y} to ${ray.B.x}, ${ray.B.y}`);
   promises.push(wrapped(token, ray, dx, dy, segment_num));
-  const res = await Promise.allSettled(promises); 
-  
+  const res = await Promise.allSettled(promises);
+
   // need to return the path from the movement for the token
   console.log("drag-ruler|AnimateToken returns", res);
   return res[res.length -1].value;  // Promise.allSettled returns an array of [{status: , value: }]; Promise.all returns an array

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -1,5 +1,5 @@
 import { MODULE_ID } from "./libwrapper.js"
-import { applyTokenSizeOffset, getTokenShape } from "./util.js";
+import { applyTokenSizeOffset, getTokenShape, getSnapPointForToken } from "./util.js";
 
 export function registerLibRuler() {
   // Wrappers for base Ruler methods
@@ -108,12 +108,15 @@ function dragRulerSetDestination(wrapped, destination) {
  */
 // TO-DO: Change libRuler to override _addWaypoint to add a switch for centering
 function dragRulerAddWaypoint(wrapped, point, center = true) {
-  log("dragRulerAddWaypoint");
+  log("dragRulerAddWaypoint", this);
   if(!this.isDragRuler) return wrapped(point, center);
 
   if(center) {
+    log(`centering ${point.x}, ${point.y}`);
     point = getSnapPointForToken(point.x, point.y, this.draggedToken);
+    
   }
+  log(`adding waypoint ${point.x}, ${point.y}`);
   return wrapped(point, false);
 }
 
@@ -321,6 +324,7 @@ function addRulerProperties() {
 	  writable: true,
 	  configurable: true
 	});
+
 }
 
 

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -181,19 +181,22 @@ function dragRulerSetDestination(wrapped, destination) {
  *				Handle measured template entity
  */
 async function dragRulerMoveToken(wrapped) {
-	if(!this.isDragRuler) return await wrapped();
-	if(this._state === Ruler.STATES.MOVING) {
-		return await wrapped();
-	} else {
-		let options = {};
-		setSnapParameterOnOptions(this, options);
-
-		if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
-			this._addWaypoint(this.destination, options);
-		} else {
-			this.dragRulerDeleteWaypoint(event, options);
-		}
+	if(!this.isDragRuler || this._state === Ruler.STATES.MOVING) {
+		const p1 = wrapped();
+		const res = await p1;
+		return res;
 	}
+
+	let options = {};
+	setSnapParameterOnOptions(this, options);
+
+	if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
+		this._addWaypoint(this.destination, options);
+	} else {
+		this.dragRulerDeleteWaypoint(event, options);
+	}
+
+	return undefined;
 }
 
 /*

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -24,6 +24,7 @@ export function registerLibRuler() {
 	libWrapper.register(settingsKey, "Ruler.prototype.cancelScheduledMeasurement", dragRulerCancelScheduledMeasurement, "WRAPPER");
 	libWrapper.register(settingsKey, "Ruler.prototype.doDeferredMeasurements", dragRulerDoDeferredMeasurements, "WRAPPER");
   libWrapper.register(settingsKey, "Ruler.prototype.testForCollision", dragRulerTestForCollision, "MIXED");
+  libWrapper.register(settingsKey, "Ruler.prototype.animateToken", dragRulerAnimateToken, "WRAPPER");
 
 	// Wrappers for libRuler RulerSegment methods
 	libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -55,7 +55,7 @@ function dragRulerClear(wrapped) {
   //this.unsetFlag(settingsKey, "previousLabels");
   //this.unsetFlag(settingsKey, "dragRulerRanges");
   log("Clear");
-  //cancelScheduledMeasurement();
+  cancelScheduledMeasurement.call(this);
   wrapped();
 }
 
@@ -91,14 +91,47 @@ function dragRulerEndMeasurement(wrapped) {
 
 function dragRulerOnMouseMove(wrapped, event) {
   log("dragRulerOnMouseMove");
-  if(!this.isDragRuler) return wrapped(event);
 
-  const offset = this.getFlag(settingsKey, "rulerOffset");
-  event.data.destination.x = event.data.destination.x + offset.x;
-  event.data.destination.y = event.data.destination.y + offset.y;
+  if(!this.isDragRuler) return wrapped(event);
+  if(this._state === Ruler.STATES.MOVING) return wrapped(event);
+
+  const mt = event._measureTime || 0;
+  const rulerOffset = this.getFlag(settingsKey, "rulerOffset");
+  event.data.destination.x = event.data.destination.x + rulerOffset.x;
+  event.data.destination.y = event.data.destination.y + rulerOffset.y;
+  const {origin, destination, originalEvent} = event.data; // in case we need it after wrap
 
   wrapped(event);
   // FYI: original drag ruler version calls this.measure with {snap: !originalEvent.shiftKey}, not {gridSpace: !originalEvent.shiftKey}
+
+  // handle deferred measurements
+  // drag ruler commit 3cbe41e2be7b4ca8dabcf98094caad15a321ddc0
+  //   If a measurement is being skipped because of the ruler's rate limiting,
+  //   schedule the measurement for later to ensure the ruler sticks to the token
+  // a bit tricky b/c we want to use a wrap if at all possible.
+  // but we cannot easily tell if _onMouseMove returned early or not.
+  // looks like _onMouseMove sets event._measureTime to the Date.now() if updating
+  // otherwise, event._measureTime is either undefined or the prior set time at start
+  // cheating a bit to use such information, but prefer wrap to not wrap.
+
+  if(event._measureTime & mt !== event._measureTime) {
+    // a measurement update occurred
+    cancelScheduledMeasurement.call(this);
+  } else {
+    // either we did not move 1/4 grid space or Date.now() - mt <= 50
+    // and so event._measureTime not updated
+    const dx = destination.x - origin.x;
+    const dy = destination.y - origin.y;
+    const distance = Math.hypot(dy, dx);
+    if ( !this.waypoints.length && (distance < (canvas.dimensions.size / 4))) return;
+
+    const measurementInterval = 50;
+    this.deferredMeasurementData = {destination, event};
+		if (!this.deferredMeasurementTimeout) {
+			this.deferredMeasurementPromise = new Promise((resolve, reject) => this.deferredMeasurementResolve = resolve);
+			this.deferredMeasurementTimeout = window.setTimeout(() => scheduleMeasurement.call(this, this.deferredMeasurementData.destination, this.deferredMeasurementData.event), measurementInterval);
+		}
+  }
 }
 
 /*

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -255,11 +255,11 @@ function dragRulerAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
   console.log(`drag-ruler|Animating ${selectedEntities.length} entities.`, entityAnimationData);
   entityAnimationData.forEach(({entity, ray, entityOffset}) => {
     console.log(`drag-ruler|Animating entity ${entity.name} with offset ${entityOffset.x}, ${entityOffset.y}`, entity, ray);
-    //wrapped(entity, ray, ...args);
-    wrapped(entity, ray, dx + entityOffset.x, dy + entityOffset.y, segment_num);
+    //wrapped(entity, ray, dx, dy, segment_num);
+    //wrapped(entity, ray, dx + entityOffset.x, dy + entityOffset.y, segment_num);
   });
 
-  //wrapped(token, ray, ..args);
+  wrapped(token, ray, dx, dy, segment_num);
 }
 
 // Wrappers for libRuler RulerSegment methods

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -30,7 +30,7 @@ export function registerLibRuler() {
 
   // Wrappers for libRuler RulerSegment methods
   libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");
-  libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.highlightPosition", dragRulerHighlightPosition, "MIXED");
+//  libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.highlightPosition", dragRulerHighlightPosition, "MIXED");
 
   addRulerProperties();
 
@@ -271,7 +271,7 @@ function dragRulerAddProperties(wrapped) {
   // TO-DO: Is there any need to store the original ray? What about when drawing lines (see original drag ruler measure function)
 }
 
-
+/*
 function dragRulerHighlightPosition(wrapped, position) {
   log(`dragRulerHighlightPosition position ${position.x}, ${position.y}`, position);
   if(!this.ruler.isDragRuler) return wrapped(position);
@@ -292,6 +292,7 @@ function dragRulerHighlightPosition(wrapped, position) {
 	}
 
 }
+*/
 
 
 // Additions to Ruler class

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -55,7 +55,7 @@ function dragRulerClear(wrapped) {
   //this.unsetFlag(settingsKey, "previousLabels");
   //this.unsetFlag(settingsKey, "dragRulerRanges");
   log("Clear");
-  cancelScheduledMeasurement();
+  //cancelScheduledMeasurement();
   wrapped();
 }
 

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -77,11 +77,7 @@ function dragRulerOnMouseMove(wrapped, event) {
   log("dragRulerOnMouseMove");
   if(!this.isDragRuler) return wrapped(event);
 
-  // TO-DO: Confirm that we need to offset origin as well as destination here.
   const offset = this.getFlag(MODULE_ID, "rulerOffset");
-  event.data.origin.x = event.data.origin.x + offset.x;
-  event.data.origin.y = event.data.origin.y + offset.y;
-
   event.data.destination.x = event.data.destination.x + offset.x;
   event.data.destination.y = event.data.destination.y + offset.y;
 

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -18,7 +18,41 @@ export function registerLibRuler() {
   libWrapper.register(MODULE_ID, "window.libRuler.RulerSegment.prototype.drawLine", dragRulerDrawLine, "MIXED");
   libWrapper.register(MODULE_ID, "window.libRuler.RulerSegment.prototype.highlightPosition", dragRulerHighlightPosition, "MIXED");
 
+  // Wrappers for event handlers for testing
+  // see what is happening with the various events
+  libWrapper.register(MODULE_ID, "Ruler.prototype._onDragStart", dragRulerOnDragStart, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Ruler.prototype._onClickLeft", dragRulerOnClickLeft, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Ruler.prototype._onClickRight", dragRulerOnClickRight, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Ruler.prototype._onMouseUp", dragRulerOnMouseUp, "WRAPPER");
+
   addRulerProperties();
+}
+
+// Wrappers for event handlers for testing
+function dragRulerOnDragStart(wrapper, event) {
+  log(`Ruler._onDragStart`, event);
+  wrapper(event);
+}
+
+function dragRulerOnClickLeft(wrapper, event) {
+  log(`Ruler._onClickLeft`, event);
+  wrapper(event);
+}
+
+function dragRulerOnClickRight(wrapper, event) {
+  log(`Ruler._onClickRight`, event);
+  wrapper(event);
+}
+
+function dragRulerOnMouseMove(wrapper, event) {
+  log(`Ruler._onMouseMove`, event);
+  wrapper(event);
+}
+
+function dragRulerOnMouseUp(wrapper, event) {
+  log(`Ruler._onMouseUp`, event);
+  wrapper(event);
 }
 
 export function log(...args) {
@@ -114,7 +148,7 @@ function dragRulerAddWaypoint(wrapped, point, center = true) {
   if(center) {
     log(`centering ${point.x}, ${point.y}`);
     point = getSnapPointForToken(point.x, point.y, this.draggedToken);
-    
+
   }
   log(`adding waypoint ${point.x}, ${point.y}`);
   return wrapped(point, false);

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -23,6 +23,7 @@ export function registerLibRuler() {
 	libWrapper.register(settingsKey, "Ruler.prototype.deferMeasurement", dragRulerDeferMeasurement, "WRAPPER");
 	libWrapper.register(settingsKey, "Ruler.prototype.cancelScheduledMeasurement", dragRulerCancelScheduledMeasurement, "WRAPPER");
 	libWrapper.register(settingsKey, "Ruler.prototype.doDeferredMeasurements", dragRulerDoDeferredMeasurements, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype.testForCollision", dragRulerTestForCollision, "MIXED");
 
 	// Wrappers for libRuler RulerSegment methods
 	libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");
@@ -125,6 +126,15 @@ function dragRulerCancelScheduledMeasurement(wrapped) {
 async function dragRulerDoDeferredMeasurements() {
 	if(this.isDragRuler) { await this.deferredMeasurementPromise; }
 	return wrapped();
+}
+
+/*
+ * Wrapper for libRuler Ruler.testForCollision
+ * Don't check for collisions if GM, so that GM can drag tokens through walls.
+ */
+function dragRulerTestForCollision(wrapped, ...args) {
+ if(this.isDragRuler && game.user.isGM) return false;
+ return wrapped(...args);
 }
 
 /*

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -234,25 +234,32 @@ function dragRulerGetMovementToken(wrapped) {
 /*
  * Wrap animate token to adjust ray for multiple tokens
  */
-function dragRulerAnimateToken(wrapped, token, ray, ...args) {
-  console.log(`drag-ruler|animating`);
+function dragRulerAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
   const selectedEntities = canvas.tokens.controlled; // should include the dragged entity, right?
-  console.log(`drag-ruler|${selectedEntities.length} selected tokens`, selectedEntities);
   const draggedEntity = this._getMovementToken();
-  console.log(`drag-ruler|draggedEntity`, draggedEntity);
+  const isToken = draggedEntity instanceof Token;
+  const animate = isToken && !game.keyboard.isDown("Alt");
+  console.log(`drag-ruler|${animate ? "animating" : "not animating"} ${selectedEntities.length} selected tokens`, draggedEntity, selectedEntities)
 
 	const entityAnimationData = selectedEntities.map(entity => {
 		const entityOffset = calculateEntityOffset(entity, draggedEntity);
 		const offsetRay = applyOffsetToRay(ray, entityOffset)
 
-		return {entity, ray: offsetRay};
+		return {entity, ray: offsetRay, entityOffset};
 	});
 
+	// probably don't want to do this b/c (1) need path from the wrapped function and (2) wrapped function has an update
+	// await draggedEntity.scene.updateEmbeddedDocuments(draggedEntity.constructor.embeddedName, updates, {animate});
+
+
   console.log(`drag-ruler|Animating ${selectedEntities.length} entities.`, entityAnimationData);
-  entityAnimationData.forEach(({entity, ray}) => {
-    console.log(`drag-ruler|Animating entity`, entity, ray);
-    wrapped(entity, ray, ...args);
+  entityAnimationData.forEach(({entity, ray, entityOffset}) => {
+    console.log(`drag-ruler|Animating entity ${entity.name} with offset ${entityOffset.x}, ${entityOffset.y}`, entity, ray);
+    //wrapped(entity, ray, ...args);
+    wrapped(entity, ray, dx + entityOffset.x, dy + entityOffset.y, segment_num);
   });
+
+  //wrapped(token, ray, ..args);
 }
 
 // Wrappers for libRuler RulerSegment methods

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -214,29 +214,37 @@ function dragRulerClearWaypoints() {
 /*
  * New delete waypoints function
  */
-function dragRulerDeleteWaypoint(event={preventDefault: () => {return}}) {
+function dragRulerDeleteWaypoint(event={preventDefault: () => {return}}, options={}) {
   log("dragRulerDeleteWaypoint");
+  options.snap = options.snap ?? true;
 
-		if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
-			event.preventDefault();
-			const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
-			const rulerOffset = this.getFlag(MODULE_ID, "rulerOffset");
-			this._removeWaypoint({x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y});
-			game.user.broadcastActivity({ruler: this});
-		}
-		else {
-			const token = this.draggedToken;
-			this._endMeasurement();
-
-			// Deactivate the drag workflow in mouse
-			token.mouseInteractionManager._deactivateDragEvents();
-			token.mouseInteractionManager.state = token.mouseInteractionManager.states.HOVER;
-
-			// This will cancel the current drag operation
-			// Pass in a fake event that hopefully is enough to allow other modules to function
-			token._onDragLeftCancel(event);
-		}
+	if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
+		event.preventDefault();
+		const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
+		const rulerOffset = this.getFlag(MODULE_ID, "rulerOffset");
+		this._removeWaypoint({x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y});
+		game.user.broadcastActivity({ruler: this});
 	}
+	else {
+		this.dragRulerAbortDrag(event);
+	}
+}
+
+/*
+ * New abort drag function
+ */
+function dragRulerAbortDrag(event={preventDefault: () => {return}}) {
+  	const token = this.draggedEntity;
+		this._endMeasurement();
+
+		// Deactivate the drag workflow in mouse
+		token.mouseInteractionManager._deactivateDragEvents();
+		token.mouseInteractionManager.state = token.mouseInteractionManager.states.HOVER;
+
+		// This will cancel the current drag operation
+		// Pass in a fake event that hopefully is enough to allow other modules to function
+		token._onDragLeftCancel(event);
+}
 
 /*
  * New recalculate function
@@ -384,6 +392,12 @@ function addRulerProperties() {
 
 	Object.defineProperty(Ruler.prototype, "dragRulerDeleteWaypoint", {
 	  value: dragRulerDeleteWaypoint,
+	  writable: true,
+	  configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerAbortDrag", {
+	  value: dragRulerAbortDrag,
 	  writable: true,
 	  configurable: true
 	});

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -237,7 +237,6 @@ function dragRulerAddProperties(wrapped) {
 
 // Additions to Ruler class
 function addRulerProperties() {
-  log(`addRulerProperties`);
   // Add a getter method to check for drag token in Ruler flags.
   Object.defineProperty(Ruler.prototype, "isDragRuler", {
     get() { return Boolean(this.getFlag(settingsKey, "draggedEntityID")); },

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -1,0 +1,272 @@
+import "MODULE_ID" from "./libwrapper.js"
+
+
+export function registerLibRuler() {
+  // Wrappers for base Ruler methods
+  libWrapper.register(MODULE_ID, "Ruler.prototype.clear", dragRulerClear, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Ruler.prototype.update", dragRulerUpdate, "MIXED");
+  libWrapper.register(MODULE_ID, "Ruler.prototype._endMeasurement", dragRulerEndMeasurement, "WRAPPER");
+
+  // Wrappers for libRuler Ruler methods
+  libWrapper.register(MODULE_ID, "Ruler.prototype.setDestination", dragRulerSetDestination, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Ruler.prototype._addWaypoint", dragRulerAddWaypoint, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Ruler.prototype.moveToken", dragRulerMoveToken, "MIXED");
+
+  // Wrappers for libRuler RulerSegment methods
+}
+
+
+// Functions copied from ruler.js that were originally in class DragRulerRuler
+
+/*
+ * Clear display of the current Ruler.
+ * Wrap for Ruler.clear
+ */
+function dragRulerClear(wrapped) {
+  this.setFlag(MODULE_ID, "previousWaypoints", []);
+  const previousLabels = this.getFlag(MODULE_ID, "previousLabels");
+  previousLabels.removeChildren().forEach(c => c.destroy());
+  this.unsetFlag(MODULE_ID, "previousLabels");
+  this.unsetFlag(MODULE_ID, "dragRulerRanges");
+  wrapped();
+}
+
+
+/*
+ * Modify update to avoid showing a GM drag ruler to non-GM players.
+ * Wrap for Ruler.update
+ */
+function dragRulerUpdate(wrapped, data) {
+  if(data.flags['drag-ruler'].draggedToken && data.draggedToken && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
+			return;
+
+  wrapped(data);
+}
+
+/*
+ * clean up after measuring
+ */
+function dragRulerEndMeasurement(wrapped) {
+  wrapped();
+  this.draggedToken = null;
+}
+
+
+
+// Wrappers for libRuler Ruler methods
+
+/*
+ * Modify destination to be the snap point for the token when snap is set.
+ * Wrap for Ruler.setDestination from libRuler.
+ * @param {Object} wrapped 	Wrapped function from libWrapper.
+ * @param {Object} destination  The destination point to which to measure. Should have at least x and y properties.
+ */
+function dragRulerSetDestination(wrapped, destination) {
+  const snap = this.getFlag(MODULE_ID, "snap");
+  if(snap) {
+    const new_dest = getSnapPointForToken(destination.x, destination.y, this.draggedToken);
+    destination.x = new_dest.x;
+    destination.y = new_dest.y;
+  }
+
+  wrapped(destination);
+}
+
+/*
+ * Wrapper for Ruler._addWaypoint
+ */
+// TO-DO: Change libRuler to override _addWaypoint to add a switch for centering
+function dragRulerAddWaypoint(wrapped, point, center = true) {
+  if(!this.isDragRuler) return wrapped(point, center);
+
+  if(center) {
+    point = getSnapPointForToken(point.x, point.y, this.draggedToken);
+  }
+  return wrapped(point, false);
+}
+
+/*
+ * New waypoint history function
+ */
+function dragRulerAddWaypointHistory(waypoints) {
+		waypoints.forEach(waypoint => waypoint.isPrevious = true);
+		this.waypoints = this.waypoints.concat(waypoints);
+		for (const waypoint of waypoints) {
+			this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
+		}
+	}
+
+/*
+ * New clear waypoints function
+ */
+function dragRulerClearWaypoints() {
+  	this.waypoints = [];
+		this.labels.removeChildren().forEach(c => c.destroy());
+	}
+
+
+/*
+ * New delete waypoints function
+ */
+function dragRulerDeleteWaypoint(event={preventDefault: () => {return}}) {
+		if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
+			event.preventDefault();
+			const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
+			const rulerOffset = this.rulerOffset;
+			this._removeWaypoint({x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y});
+			game.user.broadcastActivity({ruler: this});
+		}
+		else {
+			const token = this.draggedToken;
+			this._endMeasurement();
+
+			// Deactivate the drag workflow in mouse
+			token.mouseInteractionManager._deactivateDragEvents();
+			token.mouseInteractionManager.state = token.mouseInteractionManager.states.HOVER;
+
+			// This will cancel the current drag operation
+			// Pass in a fake event that hopefully is enough to allow other modules to function
+			token._onDragLeftCancel(event);
+		}
+	}
+
+/*
+ * New recalculate function
+ */
+async function dragRulerRecalculate(tokenIds) {
+	if (this._state !== Ruler.STATES.MEASURING)
+		return;
+
+	const dragged_token = this.draggedToken;
+
+	if (tokenIds && !tokenIds.includes(dragged_token.id))
+		return;
+	const waypoints = this.waypoints.filter(waypoint => !waypoint.isPrevious);
+	this.dragRulerClearWaypoints();
+	if (game.settings.get(settingsKey, "enableMovementHistory"))
+		this.dragRulerAddWaypointHistory(getMovementHistory(dragged_token));
+	for (const waypoint of waypoints) {
+		this.addWaypoint(waypoint, false);
+	}
+	this.measure(this.destination);
+	game.user.broadcastActivity({ruler: this});
+}
+
+export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
+		if ( destination )
+			waypoints = waypoints.concat([destination]);
+		return waypoints.slice(1).map((wp, i) => {
+			const ray =  new Ray(waypoints[i], wp);
+			ray.isPrevious = Boolean(waypoints[i].isPrevious);
+			return ray;
+		});
+	}
+
+
+async function dragRulerMoveToken(wrapped, event) {
+  if(!this.isDragRuler) return wrapped(event); // TO-DO: does this need await?
+
+  if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
+			const snap = !event.shiftKey;
+			this._addWaypoint(this.destination, snap);
+	} else {
+		  this.dragRulerDeleteWaypoint();
+	}
+}
+
+
+// Wrappers for libRuler RulerSegment methods
+
+function dragRulerAddProperties(wrapped) {
+  wrapped();
+  if(!this.ruler.isDragRuler) return;
+
+  // center waypoints? Or is this really just for terrain ruler?
+  // 	const centeredWaypoints = applyTokenSizeOffset(waypoints, this.draggedToken)
+
+  const origin =
+  this.ray.isPrevious = Boolean(origin.isPrevious);
+
+
+
+  const centeredDest = centeredWaypoints[i + 1]
+		const origin = waypoints[i];
+		const centeredOrigin = centeredWaypoints[i]
+		const label = this.labels.children[i];
+		const ray = new Ray(origin, dest);
+		const centeredRay = new Ray(centeredOrigin, centeredDest)
+		ray.isPrevious = Boolean(origin.isPrevious);
+		centeredRay.isPrevious = ray.isPrevious;
+		ray.dragRulerVisitedSpaces = origin.dragRulerVisitedSpaces;
+		centeredRay.dragRulerVisitedSpaces = ray.dragRulerVisitedSpaces;
+		ray.dragRulerFinalState = origin.dragRulerFinalState;
+		centeredRay.dragRulerFinalState = ray.dragRulerFinalState;
+
+
+}
+
+
+
+function dragRulerDrawLine(wrapped) {
+  if(!this.ruler.isDragRuler) return wrapped();
+  const opacityMultiplier = this.ray.isPrevious ? 0.33 : 1;
+  const ray = this.ray;
+  const r = this.ruler.ruler;
+  const rulerColor = this.color;
+
+  r.lineStyle(6, 0x000000, 0.5 * opacityMultiplier).moveTo(ray.A.x, ray.A.y).lineTo(ray.B.x, ray.B.y)
+			.lineStyle(4, rulerColor, 0.25 * opacityMultiplier).moveTo(ray.A.x, ray.A.y).lineTo.ray.B.x, ray.B.y);
+}
+
+
+
+// Additions to Ruler class
+
+if(game.modules.get('libruler')?.active) {
+	// Add a getter method to check for drag token in Ruler flags.
+	Object.defineProperty(Ruler.prototype, "isDragRuler", {
+		get() { return Boolean(this.getFlag(MODULE_ID, "draggedTokenID")); },
+		configurable: true
+	});
+
+	// Add a getter method to return the token for the stored token id
+	Object.defineProperty(Ruler.prototype, "draggedToken", {
+		get() {
+			const draggedTokenID = this.getFlag(MODULE_ID, "draggedTokenID");
+			if(!draggedTokenID) return undefined;
+			return canvas.tokens.get(draggedTokenID);
+		},
+		configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerAddWaypointHistory", {
+    value: dragRulerAddWaypointHistory,
+    writable: true,
+    configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerClearWaypoints", {
+	  value: dragRulerClearWaypoints,
+	  writable: true,
+	  configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerDeleteWaypoint", {
+	  value: dragRulerDeleteWaypoint,
+	  writable: true,
+	  configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerRecalculate", {
+	  value: dragRulerRecalculate,
+	  writable: true,
+	  configurable: true
+	});
+}
+
+
+
+
+
+
+

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -235,14 +235,15 @@ function dragRulerGetMovementToken(wrapped) {
  * Wrap animate token to adjust ray for multiple tokens
  */
 function dragRulerAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
-  const selectedEntities = canvas.tokens.controlled; // should include the dragged entity, right?
-  const draggedEntity = this._getMovementToken();
-  const isToken = draggedEntity instanceof Token;
+  let selectedEntities = canvas.tokens.controlled; // should include the dragged entity, right?
+  const isToken = token instanceof Token;
   const animate = isToken && !game.keyboard.isDown("Alt");
-  console.log(`drag-ruler|${animate ? "animating" : "not animating"} ${selectedEntities.length} selected tokens`, draggedEntity, selectedEntities)
+  selectedEntities = selectedEntities.filter(e => e.id !== token.id);
+
+  console.log(`drag-ruler|${animate ? "animating" : "not animating"} ${selectedEntities.length} selected tokens`, token, selectedEntities)
 
 	const entityAnimationData = selectedEntities.map(entity => {
-		const entityOffset = calculateEntityOffset(entity, draggedEntity);
+		const entityOffset = calculateEntityOffset(entity, token);
 		const offsetRay = applyOffsetToRay(ray, entityOffset)
 
 		return {entity, ray: offsetRay, entityOffset};
@@ -251,15 +252,15 @@ function dragRulerAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
 	// probably don't want to do this b/c (1) need path from the wrapped function and (2) wrapped function has an update
 	// await draggedEntity.scene.updateEmbeddedDocuments(draggedEntity.constructor.embeddedName, updates, {animate});
 
-
+  // animate the selected additional tokens
   console.log(`drag-ruler|Animating ${selectedEntities.length} entities.`, entityAnimationData);
   entityAnimationData.forEach(({entity, ray, entityOffset}) => {
     console.log(`drag-ruler|Animating entity ${entity.name} with offset ${entityOffset.x}, ${entityOffset.y}`, entity, ray);
     //wrapped(entity, ray, dx, dy, segment_num);
-    //wrapped(entity, ray, dx + entityOffset.x, dy + entityOffset.y, segment_num);
+    wrapped(entity, ray, dx + entityOffset.x, dy + entityOffset.y, segment_num);
   });
 
-  wrapped(token, ray, dx, dy, segment_num);
+  return wrapped(token, ray, dx, dy, segment_num);
 }
 
 // Wrappers for libRuler RulerSegment methods

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -1,38 +1,38 @@
 import {settingsKey} from "./settings.js"
 import { applyTokenSizeOffset, getTokenShape, getSnapPointForToken, setSnapParameterOnOptions } from "./util.js";
 import { dragRulerAddWaypointHistory,
-         dragRulerClearWaypoints,
-         dragRulerDeleteWaypoint,
-         dragRulerAbortDrag,
-         dragRulerRecalculate } from "./ruler.js";
+				 dragRulerClearWaypoints,
+				 dragRulerDeleteWaypoint,
+				 dragRulerAbortDrag,
+				 dragRulerRecalculate } from "./ruler.js";
 
 import { cancelScheduledMeasurement } from "./foundry_imports.js";
 
 export function registerLibRuler() {
-  // Wrappers for base Ruler methods
-  libWrapper.register(settingsKey, "Ruler.prototype.clear", dragRulerClear, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype.update", dragRulerUpdate, "MIXED");
-  libWrapper.register(settingsKey, "Ruler.prototype._endMeasurement", dragRulerEndMeasurement, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype._getMovementToken", dragRulerGetMovementToken, "MIXED");
-  libWrapper.register(settingsKey, "Ruler.prototype.moveToken", dragRulerMoveToken, "MIXED");
+	// Wrappers for base Ruler methods
+	libWrapper.register(settingsKey, "Ruler.prototype.clear", dragRulerClear, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype.update", dragRulerUpdate, "MIXED");
+	libWrapper.register(settingsKey, "Ruler.prototype._endMeasurement", dragRulerEndMeasurement, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype._getMovementToken", dragRulerGetMovementToken, "MIXED");
+	libWrapper.register(settingsKey, "Ruler.prototype.moveToken", dragRulerMoveToken, "MIXED");
 
-  // Wrappers for libRuler Ruler methods
-  libWrapper.register(settingsKey, "Ruler.prototype.setDestination", dragRulerSetDestination, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype._addWaypoint", dragRulerAddWaypoint, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype.deferMeasurement", dragRulerDeferMeasurement, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype.cancelScheduledMeasurement", dragRulerCancelScheduledMeasurement, "WRAPPER");
-  libWrapper.register(settingsKey, "Ruler.prototype.doDeferredMeasurements", dragRulerDoDeferredMeasurements, "WRAPPER");
+	// Wrappers for libRuler Ruler methods
+	libWrapper.register(settingsKey, "Ruler.prototype.setDestination", dragRulerSetDestination, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype._addWaypoint", dragRulerAddWaypoint, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype.deferMeasurement", dragRulerDeferMeasurement, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype.cancelScheduledMeasurement", dragRulerCancelScheduledMeasurement, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype.doDeferredMeasurements", dragRulerDoDeferredMeasurements, "WRAPPER");
 
-  // Wrappers for libRuler RulerSegment methods
-  libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");
+	// Wrappers for libRuler RulerSegment methods
+	libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");
 
-  addRulerProperties();
+	addRulerProperties();
 
-  // tell libWrapper that it can ignore the conflict warning from drag ruler not always calling
-  // the underlying method for Ruler.moveToken. (i.e., drag ruler interrupts it
-  // if just adding or deleting a waypoint)
-  libWrapper.ignore_conflicts(settingsKey, "libruler", "Ruler.prototype.moveToken");
+	// tell libWrapper that it can ignore the conflict warning from drag ruler not always calling
+	// the underlying method for Ruler.moveToken. (i.e., drag ruler interrupts it
+	// if just adding or deleting a waypoint)
+	libWrapper.ignore_conflicts(settingsKey, "libruler", "Ruler.prototype.moveToken");
 }
 
 
@@ -43,8 +43,8 @@ export function registerLibRuler() {
  * Wrap for Ruler.clear
  */
 function dragRulerClear(wrapped) {
-  this.cancelScheduledMeasurement();
-  wrapped();
+	this.cancelScheduledMeasurement();
+	wrapped();
 }
 
 
@@ -53,19 +53,19 @@ function dragRulerClear(wrapped) {
  * Wrap for Ruler.update
  */
 function dragRulerUpdate(wrapped, data) {
-  if(this.draggedEntity && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
-      return;
+	if(this.draggedEntity && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
+			return;
 
-  wrapped(data);
+	wrapped(data);
 }
 
 /*
  * clean up after measuring
  */
 function dragRulerEndMeasurement(wrapped) {
-  this.unsetFlag(settingsKey, "draggedEntityID");
-  this.unsetFlag(settingsKey, "rulerOffset");
-  wrapped();
+	this.unsetFlag(settingsKey, "draggedEntityID");
+	this.unsetFlag(settingsKey, "rulerOffset");
+	wrapped();
 }
 
 
@@ -79,14 +79,14 @@ function dragRulerEndMeasurement(wrapped) {
  */
 
 function dragRulerOnMouseMove(wrapped, event) {
-  if(!this.isDragRuler) return wrapped(event);
+	if(!this.isDragRuler) return wrapped(event);
 
-  const offset = this.getFlag(settingsKey, "rulerOffset");
-  event.data.destination.x = event.data.destination.x + offset.x;
-  event.data.destination.y = event.data.destination.y + offset.y;
+	const offset = this.getFlag(settingsKey, "rulerOffset");
+	event.data.destination.x = event.data.destination.x + offset.x;
+	event.data.destination.y = event.data.destination.y + offset.y;
 
-  wrapped(event);
-  // FYI: original drag ruler version calls this.measure with {snap: !originalEvent.shiftKey}, not {gridSpace: !originalEvent.shiftKey}
+	wrapped(event);
+	// FYI: original drag ruler version calls this.measure with {snap: !originalEvent.shiftKey}, not {gridSpace: !originalEvent.shiftKey}
 }
 
 // The below deferMeasurement and cancelScheduleMeasurement handle situation in which
@@ -99,14 +99,14 @@ function dragRulerOnMouseMove(wrapped, event) {
  *
  */
 function dragRulerDeferMeasurement(wrapped, destination, event) {
-  if(this.isDragRuler) {
-    this.deferredMeasurementData = {destination, event};
-    if (!this.deferredMeasurementTimeout) {
-      this.deferredMeasurementPromise = new Promise((resolve, reject) => this.deferredMeasurementResolve = resolve);
-      this.deferredMeasurementTimeout = window.setTimeout(() => this.scheduleMeasurement(this.deferredMeasurementData.destination, this.deferredMeasurementData.event));
-    }
-  }
-  return wrapped(destination, event);
+	if(this.isDragRuler) {
+		this.deferredMeasurementData = {destination, event};
+		if (!this.deferredMeasurementTimeout) {
+			this.deferredMeasurementPromise = new Promise((resolve, reject) => this.deferredMeasurementResolve = resolve);
+			this.deferredMeasurementTimeout = window.setTimeout(() => this.scheduleMeasurement(this.deferredMeasurementData.destination, this.deferredMeasurementData.event));
+		}
+	}
+	return wrapped(destination, event);
 }
 
 /*
@@ -114,8 +114,8 @@ function dragRulerDeferMeasurement(wrapped, destination, event) {
  * Uses existing internal drag ruler function to avoid unnecessary copy
  */
 function dragRulerCancelScheduledMeasurement(wrapped) {
-  if(this.isDragRuler) { cancelScheduledMeasurement.call(this); }
-  return wrapped();
+	if(this.isDragRuler) { cancelScheduledMeasurement.call(this); }
+	return wrapped();
 }
 
 /*
@@ -123,76 +123,76 @@ function dragRulerCancelScheduledMeasurement(wrapped) {
  * This is called from Ruler.moveToken and will catch the deferred promise in dragRulerDeferMeasurement above
  */
 async function dragRulerDoDeferredMeasurements() {
-  if(this.isDragRuler) { await this.deferredMeasurementPromise; }
-  return wrapped();
+	if(this.isDragRuler) { await this.deferredMeasurementPromise; }
+	return wrapped();
 }
 
 /*
  * Modify destination to be the snap point for the token when snap is set.
  * Wrap for Ruler.setDestination from libRuler.
- * @param {Object} wrapped  Wrapped function from libWrapper.
- * @param {Object} destination  The destination point to which to measure. Should have at least x and y properties.
+ * @param {Object} wrapped	Wrapped function from libWrapper.
+ * @param {Object} destination	The destination point to which to measure. Should have at least x and y properties.
  */
 function dragRulerSetDestination(wrapped, destination) {
-  const snap = this.getFlag(settingsKey, "snap");
-  if(snap) {
-    const new_dest = getSnapPointForToken(destination.x, destination.y, this.draggedEntity);
-    destination.x = new_dest.x;
-    destination.y = new_dest.y;
-  }
+	const snap = this.getFlag(settingsKey, "snap");
+	if(snap) {
+		const new_dest = getSnapPointForToken(destination.x, destination.y, this.draggedEntity);
+		destination.x = new_dest.x;
+		destination.y = new_dest.y;
+	}
 
-  wrapped(destination);
+	wrapped(destination);
 }
 
 /*
  * Wrapper for Ruler.moveToken
  * Drag ruler original code breaks this out into two functions;
- *   - moveToken just adds or deletes waypoints; intercepting the space bar or right-click press
- *   - moveEntities is basically Ruler.moveToken with modifications
+ *	 - moveToken just adds or deletes waypoints; intercepting the space bar or right-click press
+ *	 - moveEntities is basically Ruler.moveToken with modifications
  * To conform to libRuler and Foundry expectations, combine back into single wrap here
- *   - check a flag to start the actual movement
+ *	 - check a flag to start the actual movement
  * TO-DO: Handle multiple entities
- *        Handle measured template entity
+ *				Handle measured template entity
  */
 async function dragRulerMoveToken(wrapped) {
-  if(!this.isDragRuler) return await wrapped();
-  if(this._state === Ruler.STATES.MOVING) {
-    return await wrapped();
-  } else {
-    let options = {};
-    setSnapParameterOnOptions(this, options);
+	if(!this.isDragRuler) return await wrapped();
+	if(this._state === Ruler.STATES.MOVING) {
+		return await wrapped();
+	} else {
+		let options = {};
+		setSnapParameterOnOptions(this, options);
 
-    if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
-      this._addWaypoint(this.destination, options);
-    } else {
-      this.dragRulerDeleteWaypoint(event, options);
-    }
-  }
+		if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
+			this._addWaypoint(this.destination, options);
+		} else {
+			this.dragRulerDeleteWaypoint(event, options);
+		}
+	}
 }
 
 /*
  * Wrapper for Ruler._addWaypoint
  */
 function dragRulerAddWaypoint(wrapped, point, center = true) {
-  if(!this.isDragRuler) return wrapped(point, center);
+	if(!this.isDragRuler) return wrapped(point, center);
 
-  if(center) {
-    point = getSnapPointForToken(point.x, point.y, this.draggedEntity);
+	if(center) {
+		point = getSnapPointForToken(point.x, point.y, this.draggedEntity);
 
-  }
-  return wrapped(point, false);
+	}
+	return wrapped(point, false);
 }
 
 
 export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
-    if ( destination )
-      waypoints = waypoints.concat([destination]);
-    return waypoints.slice(1).map((wp, i) => {
-      const ray =  new Ray(waypoints[i], wp);
-      ray.isPrevious = Boolean(waypoints[i].isPrevious);
-      return ray;
-    });
-  }
+		if ( destination )
+			waypoints = waypoints.concat([destination]);
+		return waypoints.slice(1).map((wp, i) => {
+			const ray =	 new Ray(waypoints[i], wp);
+			ray.isPrevious = Boolean(waypoints[i].isPrevious);
+			return ray;
+		});
+	}
 
 
 /*
@@ -203,91 +203,91 @@ export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
 // TO-DO: Deal with multiple selected tokens
 // See drag ruler original version of moveTokens in foundry_imports.js
 function dragRulerGetMovementToken(wrapped) {
-  if(!this.isDragRuler) return wrapped();
-  return this.draggedEntity;
+	if(!this.isDragRuler) return wrapped();
+	return this.draggedEntity;
 }
 
 // TO-DO: Deal with multiple selected token animation
 
 // Wrappers for libRuler RulerSegment methods
 function dragRulerAddProperties(wrapped) {
-  wrapped();
-  if(!this.ruler.isDragRuler) return;
+	wrapped();
+	if(!this.ruler.isDragRuler) return;
 
-  // center the segments
-  // TO-DO: Can Terrain Ruler handle its part separately? So just center everything here?
-  // See if (!terrainRulerAvailable) in drag ruler original measure function
-  const centeredWaypoints = applyTokenSizeOffset([this.ray.A, this.ray.B], this.ruler.draggedEntity);
-  centeredWaypoints.forEach(w => [w.x, w.y] = canvas.grid.getCenter(w.x, w.y));
+	// center the segments
+	// TO-DO: Can Terrain Ruler handle its part separately? So just center everything here?
+	// See if (!terrainRulerAvailable) in drag ruler original measure function
+	const centeredWaypoints = applyTokenSizeOffset([this.ray.A, this.ray.B], this.ruler.draggedEntity);
+	centeredWaypoints.forEach(w => [w.x, w.y] = canvas.grid.getCenter(w.x, w.y));
 
-  this.ray = new Ray(centeredWaypoints[0], centeredWaypoints[1]);
+	this.ray = new Ray(centeredWaypoints[0], centeredWaypoints[1]);
 
-  // can pull origin information from the original waypoints
-  // segment 0 would have origin waypoint 0, destination waypoint 1, etc.
-  const origin = this.ruler.waypoints[this.segment_num];
-  this.ray.isPrevious = Boolean(origin.isPrevious);
-  this.ray.dragRulerVisitedSpaces = origin.dragRulerVisitedSpaces;
-  this.ray.dragRulerFinalState = origin.dragRulerFinalState;
+	// can pull origin information from the original waypoints
+	// segment 0 would have origin waypoint 0, destination waypoint 1, etc.
+	const origin = this.ruler.waypoints[this.segment_num];
+	this.ray.isPrevious = Boolean(origin.isPrevious);
+	this.ray.dragRulerVisitedSpaces = origin.dragRulerVisitedSpaces;
+	this.ray.dragRulerFinalState = origin.dragRulerFinalState;
 
-  // set opacity for drawing the line and the highlight
-  const opacity_mult = this.ray.isPrevious ? 0.33 : 1;
-  this.opacityMultipliers.line = opacity_mult;
-  this.opacityMultipliers.highlight = opacity_mult;
+	// set opacity for drawing the line and the highlight
+	const opacity_mult = this.ray.isPrevious ? 0.33 : 1;
+	this.opacityMultipliers.line = opacity_mult;
+	this.opacityMultipliers.highlight = opacity_mult;
 }
 
 // Additions to Ruler class
 function addRulerProperties() {
-  // Add a getter method to check for drag token in Ruler flags.
-  Object.defineProperty(Ruler.prototype, "isDragRuler", {
-    get() { return Boolean(this.getFlag(settingsKey, "draggedEntityID")); },
-    configurable: true
-  });
+	// Add a getter method to check for drag token in Ruler flags.
+	Object.defineProperty(Ruler.prototype, "isDragRuler", {
+		get() { return Boolean(this.getFlag(settingsKey, "draggedEntityID")); },
+		configurable: true
+	});
 
-  // Add a getter method to return the token for the stored token id
-  Object.defineProperty(Ruler.prototype, "draggedEntity", {
-    get() {
-      const draggedEntityID = this.getFlag(settingsKey, "draggedEntityID");
-      if(!draggedEntityID) return undefined;
-      return canvas.tokens.get(draggedEntityID);
-    },
-    configurable: true
-  });
+	// Add a getter method to return the token for the stored token id
+	Object.defineProperty(Ruler.prototype, "draggedEntity", {
+		get() {
+			const draggedEntityID = this.getFlag(settingsKey, "draggedEntityID");
+			if(!draggedEntityID) return undefined;
+			return canvas.tokens.get(draggedEntityID);
+		},
+		configurable: true
+	});
 
-  Object.defineProperty(Ruler.prototype, "dragRulerAddWaypointHistory", {
-    value: dragRulerAddWaypointHistory,
-    writable: true,
-    configurable: true
-  });
+	Object.defineProperty(Ruler.prototype, "dragRulerAddWaypointHistory", {
+		value: dragRulerAddWaypointHistory,
+		writable: true,
+		configurable: true
+	});
 
-  Object.defineProperty(Ruler.prototype, "dragRulerClearWaypoints", {
-    value: dragRulerClearWaypoints,
-    writable: true,
-    configurable: true
-  });
+	Object.defineProperty(Ruler.prototype, "dragRulerClearWaypoints", {
+		value: dragRulerClearWaypoints,
+		writable: true,
+		configurable: true
+	});
 
-  Object.defineProperty(Ruler.prototype, "dragRulerDeleteWaypoint", {
-    value: dragRulerDeleteWaypoint,
-    writable: true,
-    configurable: true
-  });
+	Object.defineProperty(Ruler.prototype, "dragRulerDeleteWaypoint", {
+		value: dragRulerDeleteWaypoint,
+		writable: true,
+		configurable: true
+	});
 
-  Object.defineProperty(Ruler.prototype, "dragRulerAbortDrag", {
-    value: dragRulerAbortDrag,
-    writable: true,
-    configurable: true
-  });
+	Object.defineProperty(Ruler.prototype, "dragRulerAbortDrag", {
+		value: dragRulerAbortDrag,
+		writable: true,
+		configurable: true
+	});
 
-  Object.defineProperty(Ruler.prototype, "dragRulerRecalculate", {
-    value: dragRulerRecalculate,
-    writable: true,
-    configurable: true
-  });
+	Object.defineProperty(Ruler.prototype, "dragRulerRecalculate", {
+		value: dragRulerRecalculate,
+		writable: true,
+		configurable: true
+	});
 
-  Object.defineProperty(Ruler, "dragRulerGetRaysFromWaypoints", {
-    value: dragRulerGetRaysFromWaypoints,
-    writable: true,
-    configurable: true
-  });
+	Object.defineProperty(Ruler, "dragRulerGetRaysFromWaypoints", {
+		value: dragRulerGetRaysFromWaypoints,
+		writable: true,
+		configurable: true
+	});
 }
 
 

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -28,6 +28,12 @@ export function registerLibRuler() {
   libWrapper.register(settingsKey, "KeyboardManager.prototype._onSpace", dragRulerOnSpace, "WRAPPER");
 
   addRulerProperties();
+
+  // tell libWrapper that it can ignore the conflict warning from drag ruler not always calling
+  // the underlying method for Ruler.moveToken. (i.e., drag ruler interrupts it 
+  // if just adding or deleting a waypoint)
+  libWrapper.ignore_conflicts(settingsKey, "libruler", "Ruler.prototype.moveToken");
+
 }
 
 // Wrappers for event handlers for testing

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -1,4 +1,4 @@
-import "MODULE_ID" from "./libwrapper.js"
+import { MODULE_ID } from "./libwrapper.js"
 
 export function registerLibRuler() {
   // Wrappers for base Ruler methods
@@ -256,8 +256,8 @@ function dragRulerDrawLine(wrapped) {
   const r = this.ruler.ruler;
   const rulerColor = this.color;
 
-  r.lineStyle(6, 0x000000, 0.5 * opacityMultiplier).moveTo(ray.A.x, ray.A.y).lineTo(ray.B.x, ray.B.y)
-			.lineStyle(4, rulerColor, 0.25 * opacityMultiplier).moveTo(ray.A.x, ray.A.y).lineTo.ray.B.x, ray.B.y);
+  r.lineStyle(6, 0x000000, 0.5 * opacityMultiplier).moveTo(ray.A.x, ray.A.y).lineTo(ray.B.x, ray.B.y).
+    lineStyle(4, rulerColor, 0.25 * opacityMultiplier).moveTo(ray.A.x, ray.A.y).lineTo(ray.B.x, ray.B.y);
 }
 
 

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -143,7 +143,7 @@ function dragRulerCancelScheduledMeasurement(wrapped) {
  * Wrap for libRuler Ruler.doDeferredMeasurement
  * This is called from Ruler.moveToken and will catch the deferred promise in dragRulerDeferMeasurement above
  */
-function dragRulerDoDeferredMeasurements() {
+async function dragRulerDoDeferredMeasurements() {
   if(this.isDragRuler) { await this.deferredMeasurementPromise; }
   return wrapped();
 }

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -136,10 +136,10 @@ function dragRulerTestForCollision(wrapped, rays) {
  // taken from foundry_imports.js moveEntities function
  if(this.isDragRuler) {
    if(game.user.isGM) return false;
-   draggedEntity = this._getMovementToken();
+   const draggedEntity = this._getMovementToken();
 
    if(draggedEntity instanceof Token) {
-     selectedEntities = canvas.tokens.controlled;
+     const selectedEntities = canvas.tokens.controlled;
      const hasCollision = selectedEntities.some(token => {
 			 const offset = calculateEntityOffset(token, draggedEntity);
 			 const offsetRays = rays.filter(ray => !ray.isPrevious).map(ray => applyOffsetToRay(ray, offset))

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -6,7 +6,7 @@ import { dragRulerAddWaypointHistory,
 				 dragRulerAbortDrag,
 				 dragRulerRecalculate } from "./ruler.js";
 
-import { cancelScheduledMeasurement, calculateEntityOffset } from "./foundry_imports.js";
+import { cancelScheduledMeasurement, calculateEntityOffset, applyOffsetToRay } from "./foundry_imports.js";
 
 export function registerLibRuler() {
 	// Wrappers for base Ruler methods
@@ -234,19 +234,25 @@ function dragRulerGetMovementToken(wrapped) {
 /*
  * Wrap animate token to adjust ray for multiple tokens
  */
-function dragRulerAnimateToken(token, ray, ...args) {
+function dragRulerAnimateToken(wrapped, token, ray, ...args) {
+  console.log(`drag-ruler|animating`);
   const selectedEntities = canvas.tokens.controlled; // should include the dragged entity, right?
+  console.log(`drag-ruler|${selectedEntities.length} selected tokens`, selectedEntities);
   const draggedEntity = this._getMovementToken();
-	const entityAnimationData = entities.map(entity => {
+  console.log(`drag-ruler|draggedEntity`, draggedEntity);
+
+	const entityAnimationData = selectedEntities.map(entity => {
 		const entityOffset = calculateEntityOffset(entity, draggedEntity);
 		const offsetRay = applyOffsetToRay(ray, entityOffset)
 
 		return {entity, ray: offsetRay};
 	});
 
-  entityAnimationData.forEach(({entity, ray} => {
+  console.log(`drag-ruler|Animating ${selectedEntities.length} entities.`, entityAnimationData);
+  entityAnimationData.forEach(({entity, ray}) => {
+    console.log(`drag-ruler|Animating entity`, entity, ray);
     wrapped(entity, ray, ...args);
-  }));
+  });
 }
 
 // Wrappers for libRuler RulerSegment methods

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -224,15 +224,29 @@ export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
  * Wrap for Ruler._getMovementToken()
  */
 
-
-// TO-DO: Deal with multiple selected tokens
 // See drag ruler original version of moveTokens in foundry_imports.js
 function dragRulerGetMovementToken(wrapped) {
 	if(!this.isDragRuler) return wrapped();
 	return this.draggedEntity;
 }
 
-// TO-DO: Deal with multiple selected token animation
+/*
+ * Wrap animate token to adjust ray for multiple tokens
+ */
+function dragRulerAnimateToken(token, ray, ...args) {
+  const selectedEntities = canvas.tokens.controlled; // should include the dragged entity, right?
+  const draggedEntity = this._getMovementToken();
+	const entityAnimationData = entities.map(entity => {
+		const entityOffset = calculateEntityOffset(entity, draggedEntity);
+		const offsetRay = applyOffsetToRay(ray, entityOffset)
+
+		return {entity, ray: offsetRay};
+	});
+
+  entityAnimationData.forEach(({entity, ray} => {
+    wrapped(entity, ray, ...args);
+  }));
+}
 
 // Wrappers for libRuler RulerSegment methods
 function dragRulerAddProperties(wrapped) {

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -24,7 +24,7 @@ export function registerLibRuler() {
   libWrapper.register(MODULE_ID, "Ruler.prototype._onDragStart", dragRulerOnDragStart, "WRAPPER");
   libWrapper.register(MODULE_ID, "Ruler.prototype._onClickLeft", dragRulerOnClickLeft, "WRAPPER");
   libWrapper.register(MODULE_ID, "Ruler.prototype._onClickRight", dragRulerOnClickRight, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
+  //libWrapper.register(MODULE_ID, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
   libWrapper.register(MODULE_ID, "Ruler.prototype._onMouseUp", dragRulerOnMouseUp, "WRAPPER");
   libWrapper.register(MODULE_ID, "KeyboardManager.prototype._onSpace", dragRulerOnSpace, "WRAPPER");
 
@@ -47,10 +47,13 @@ function dragRulerOnClickRight(wrapper, event) {
   wrapper(event);
 }
 
+/*
+ * Defined below
 function dragRulerOnMouseMove(wrapper, event) {
   log(`Ruler._onMouseMove`, event);
   wrapper(event);
 }
+*/
 
 function dragRulerOnMouseUp(wrapper, event) {
   log(`Ruler._onMouseUp`, event);

--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -7,16 +7,17 @@ import { onEntityLeftDragStart,
 
 import { removeLastHistoryEntryIfAt } from "./movement_tracking.js";
 export const MODULE_ID = "drag-ruler";
+import { settingsKey } from "./settings.js"
 
 export function registerLibWrapper() {
-  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftStart", onTokenLeftDragStartWrap, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftMove", onDragLeftMoveWrap, "WRAPPER");
-  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftDrop", onDragLeftDropWrap, "MIXED");
-  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftCancel", onDragLeftCancelWrap, "MIXED");
+  libWrapper.register(settingsKey, "Token.prototype._onDragLeftStart", onTokenLeftDragStartWrap, "WRAPPER");
+  libWrapper.register(settingsKey, "Token.prototype._onDragLeftMove", onDragLeftMoveWrap, "WRAPPER");
+  libWrapper.register(settingsKey, "Token.prototype._onDragLeftDrop", onDragLeftDropWrap, "MIXED");
+  libWrapper.register(settingsKey, "Token.prototype._onDragLeftCancel", onDragLeftCancelWrap, "MIXED");
 
-  libWrapper.register(MODULE_ID, "KeyboardManager.prototype._handleKeys", handleKeysWrap, "MIXED");
+  libWrapper.register(settingsKey, "KeyboardManager.prototype._handleKeys", handleKeysWrap, "MIXED");
 
-  libWrapper.register(MODULE_ID, "TokenLayer.prototype.undoHistory", dragRulerUndoHistory, "WRAPPER");
+  libWrapper.register(settingsKey, "TokenLayer.prototype.undoHistory", dragRulerUndoHistory, "WRAPPER");
 }
 
 // simple wraps to keep the original functionality when not using libWrapper
@@ -54,7 +55,7 @@ function handleKeysWrap(wrapped, event, key, up) {
 async function dragRulerUndoHistory(wrapped) {
   const historyEntry = this.history[this.history.length - 1];
   const returnValue = await wrapped();
-  
+
   if (historyEntry.type === "update") {
     for (const entry of historyEntry.data) {
       const token = canvas.tokens.get(entry._id);

--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -5,7 +5,7 @@ import { onTokenLeftDragStart,
          onTokenDragLeftCancel,
          handleKeys } from "./main.js";
 
-const MODULE_ID = "drag-ruler";
+export const MODULE_ID = "drag-ruler";
 
 export function registerLibWrapper() {
   libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftStart", onTokenLeftDragStartWrap, "WRAPPER");

--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -1,0 +1,49 @@
+// Hooks using libWrapper
+import { onTokenLeftDragStart,
+         onTokenLeftDragMove,
+         onTokenDragLeftDrop,
+         onTokenDragLeftCancel,
+         handleKeys } from "./main.js";
+
+const MODULE_ID = "drag-ruler";
+
+export function registerLibWrapper() {
+  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftStart", onTokenLeftDragStartWrap, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftMove", onDragLeftMoveWrap, "WRAPPER");
+  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftDrop", onDragLeftDropWrap, "MIXED");
+  libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftCancel", onDragLeftCancelWrap, "MIXED");
+
+  libWrapper.register(MODULE_ID, "KeyboardManager.prototype._handleKeys", handleKeysWrap, "MIXED");
+}
+
+// simple wraps to keep the original functionality when not using libWrapper
+function onTokenLeftDragStartWrap(wrapped, event) {
+  wrapped(event);
+  onTokenLeftDragStart.call(this, event);
+}
+
+function onDragLeftMoveWrap(wrapped, event) {
+  wrapped(event);
+  onTokenLeftDragMove.call(this, event);
+}
+
+function onDragLeftDropWrap(wrapped, event) {
+  const eventHandled = onTokenDragLeftDrop.call(this, event);
+  if(!eventHandled) {
+    wrapped(event);
+  }
+}
+
+function onDragLeftCancelWrap(wrapped, event) {
+  const eventHandled = onTokenDragLeftCancel.call(this, event);
+  if(!eventHandled) {
+    wrapped(event);
+  }
+}
+
+function handleKeysWrap(wrapped, event, key, up) {
+  const eventHandled = handleKeys.call(this, event, key, up);
+  if(!eventHandled) {
+    wrapped(event, key, up);
+  }
+}

--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -15,7 +15,7 @@ export function registerLibWrapper() {
   libWrapper.register(settingsKey, "Token.prototype._onDragLeftDrop", onDragLeftDropWrap, "MIXED");
   libWrapper.register(settingsKey, "Token.prototype._onDragLeftCancel", onDragLeftCancelWrap, "MIXED");
 
-  libWrapper.register(settingsKey, "KeyboardManager.prototype._handleKeys", handleKeysWrap, "MIXED");
+  libWrapper.register(settingsKey, "KeyboardManager.prototype._handleKeyboardEvent", handleKeysWrap, "MIXED");
 
   libWrapper.register(settingsKey, "TokenLayer.prototype.undoHistory", dragRulerUndoHistory, "WRAPPER");
 }
@@ -45,10 +45,10 @@ function onDragLeftCancelWrap(wrapped, event) {
   }
 }
 
-function handleKeysWrap(wrapped, event, key, up) {
-  const eventHandled = handleKeys.call(this, event, key, up);
+function handleKeysWrap(wrapped, event, up) {
+  const eventHandled = handleKeys.call(this, event, up);
   if(!eventHandled) {
-    wrapped(event, key, up);
+    wrapped(event, up);
   }
 }
 

--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -1,8 +1,8 @@
 // Hooks using libWrapper
-import { onTokenLeftDragStart,
-         onTokenLeftDragMove,
-         onTokenDragLeftDrop,
-         onTokenDragLeftCancel,
+import { onEntityLeftDragStart,
+         onEntityLeftDragMove,
+         onEntityDragLeftDrop,
+         onEntityDragLeftCancel,
          handleKeys } from "./main.js";
 
 export const MODULE_ID = "drag-ruler";
@@ -19,23 +19,23 @@ export function registerLibWrapper() {
 // simple wraps to keep the original functionality when not using libWrapper
 function onTokenLeftDragStartWrap(wrapped, event) {
   wrapped(event);
-  onTokenLeftDragStart.call(this, event);
+  onEntityLeftDragStart.call(this, event);
 }
 
 function onDragLeftMoveWrap(wrapped, event) {
   wrapped(event);
-  onTokenLeftDragMove.call(this, event);
+  onEntityLeftDragMove.call(this, event);
 }
 
 function onDragLeftDropWrap(wrapped, event) {
-  const eventHandled = onTokenDragLeftDrop.call(this, event);
+  const eventHandled = onEntityDragLeftDrop.call(this, event);
   if(!eventHandled) {
     wrapped(event);
   }
 }
 
 function onDragLeftCancelWrap(wrapped, event) {
-  const eventHandled = onTokenDragLeftCancel.call(this, event);
+  const eventHandled = onEntityDragLeftCancel.call(this, event);
   if(!eventHandled) {
     wrapped(event);
   }

--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -5,6 +5,7 @@ import { onEntityLeftDragStart,
          onEntityDragLeftCancel,
          handleKeys } from "./main.js";
 
+import { removeLastHistoryEntryIfAt } from "./movement_tracking.js";
 export const MODULE_ID = "drag-ruler";
 
 export function registerLibWrapper() {
@@ -14,6 +15,8 @@ export function registerLibWrapper() {
   libWrapper.register(MODULE_ID, "Token.prototype._onDragLeftCancel", onDragLeftCancelWrap, "MIXED");
 
   libWrapper.register(MODULE_ID, "KeyboardManager.prototype._handleKeys", handleKeysWrap, "MIXED");
+
+  libWrapper.register(MODULE_ID, "TokenLayer.prototype.undoHistory", dragRulerUndoHistory, "WRAPPER");
 }
 
 // simple wraps to keep the original functionality when not using libWrapper
@@ -47,3 +50,17 @@ function handleKeysWrap(wrapped, event, key, up) {
     wrapped(event, key, up);
   }
 }
+
+async function dragRulerUndoHistory(wrapped) {
+  const historyEntry = this.history[this.history.length - 1];
+  const returnValue = await wrapped();
+  
+  if (historyEntry.type === "update") {
+    for (const entry of historyEntry.data) {
+      const token = canvas.tokens.get(entry._id);
+      removeLastHistoryEntryIfAt(token, entry.x, entry.y);
+    }
+  }
+  return returnValue;
+}
+

--- a/src/main.js
+++ b/src/main.js
@@ -16,13 +16,11 @@ import {isClose, setSnapParameterOnOptions} from "./util.js";
 Hooks.once("init", () => {
 	registerSettings()
 	initApi()
-	hookDragHandlers(Token);
-	hookDragHandlers(MeasuredTemplate);
-	hookKeyboardManagerFunctions()
 	hookLayerFunctions();
 
         if(!game.modules.get('lib-wrapper')?.active) {
-	  hookTokenDragHandlers()
+	  hookDragHandlers(Token)
+          hookDragHandlers(MeasuredTemplate);
 	  hookKeyboardManagerFunctions()
         } else {
           registerLibWrapper();

--- a/src/main.js
+++ b/src/main.js
@@ -287,20 +287,13 @@ export function startDragRuler(options, measureImmediately=true) {
 function onEntityLeftDragMove(event) {
   log(`onTokenLeftDragMove`, event);
 	const ruler = canvas.controls.ruler
-
-/*
-        if(ruler.waypoints.length < 1) {
-          log(`No waypoints found; restarting.`);
-          return onEntityLeftDragStart.call(this, event);
-        }
-*/
-  if (ruler.isDragRuler) {
-    if(game.modules.get('libruler')?.active) {
-      ruler._onMouseMove(event);
-    } else {
-      onMouseMove.call(ruler, event)
-    }
-  }
+	if (ruler.isDragRuler) {
+	  if(game.modules.get('libruler')?.active) {
+	    ruler._onMouseMove(event);
+	  } else {
+	    onMouseMove.call(ruler, event)
+	  }
+	}
 }
 
 export function onEntityDragLeftDrop(event) {
@@ -343,9 +336,9 @@ export function onEntityDragLeftCancel(event) {
   let options = {};
   setSnapParameterOnOptions(ruler, options);
 
-  if (ruler._state === Ruler.STATES.INACTIVE) {
-    if (!swapSpacebarRightClick)
-      return false;
+	if (ruler._state === Ruler.STATES.INACTIVE) {
+		if (!swapSpacebarRightClick)
+			return false;
           log('Starting drag ruler');
 		startDragRuler.call(this, options);
 		event.preventDefault();

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import {registerSettings, settingsKey} from "./settings.js"
 import {recalculate} from "./socket.js";
 import {SpeedProvider} from "./speed_provider.js"
 import {isClose, setSnapParameterOnOptions} from "./util.js";
+import {registerLibWrapper} from "./libwrapper.js"
 
 Hooks.once("init", () => {
 	registerSettings()
@@ -18,6 +19,13 @@ Hooks.once("init", () => {
 	hookDragHandlers(MeasuredTemplate);
 	hookKeyboardManagerFunctions()
 	hookLayerFunctions();
+
+        if(!game.modules.get('lib-wrapper')?.active) {
+	  hookTokenDragHandlers()
+	  hookKeyboardManagerFunctions()
+        } else {
+          registerLibWrapper();
+        }
 
 	Ruler = DragRulerRuler;
 
@@ -112,7 +120,7 @@ function hookLayerFunctions() {
 	}
 }
 
-function handleKeys(event, key, up) {
+export function handleKeys(event, key, up) {
 	if (event.repeat || this.hasFocus)
 		return false
 
@@ -182,6 +190,8 @@ function onKeyEscape(up) {
 
 function onEntityLeftDragStart(event) {
 	const isToken = this instanceof Token;
+	if (!currentSpeedProvider.usesRuler(this))
+		return
 	const ruler = canvas.controls.ruler
 	ruler.draggedEntity = this;
 	let entityCenter;

--- a/src/main.js
+++ b/src/main.js
@@ -229,7 +229,7 @@ function onEntityLeftDragStart(event) {
 	}
 }
 
-function startDragRuler(options, measureImmediately=true) {
+export function startDragRuler(options, measureImmediately=true) {
 	const isToken = this instanceof Token;
 	if (isToken && !currentSpeedProvider.usesRuler(this))
 		return;

--- a/src/main.js
+++ b/src/main.js
@@ -15,18 +15,18 @@ import {registerLibRuler, log} from "./libruler.js"
 import {isClose, setSnapParameterOnOptions} from "./util.js";
 
 Hooks.once("init", () => {
-	registerSettings()
-	initApi()
-	hookLayerFunctions();
+  registerSettings()
+  initApi()
+  hookLayerFunctions();
 
         if(!game.modules.get('lib-wrapper')?.active) {
-	  hookDragHandlers(Token)
+    hookDragHandlers(Token)
           hookDragHandlers(MeasuredTemplate);
-	  hookKeyboardManagerFunctions()
+    hookKeyboardManagerFunctions()
         } else {
           registerLibWrapper();
         }
-  if(!game.modules.get('libruler')?.active)	Ruler = DragRulerRuler;
+  if(!game.modules.get('libruler')?.active) Ruler = DragRulerRuler;
 
 	window.dragRuler = {
 		getColorForDistanceAndToken,
@@ -39,9 +39,9 @@ Hooks.once("init", () => {
 })
 
 Hooks.once("ready", () => {
-	performMigrations()
-	checkDependencies();
-	Hooks.callAll("dragRuler.ready", SpeedProvider)
+  performMigrations()
+  checkDependencies();
+  Hooks.callAll("dragRuler.ready", SpeedProvider)
 })
 
 Hooks.on("canvasReady", () => {
@@ -59,12 +59,12 @@ Hooks.on("canvasReady", () => {
 });
 
 Hooks.on("getCombatTrackerEntryContext", function (html, menu) {
-	const entry = {
-		name: "drag-ruler.resetMovementHistory",
-		icon: '<i class="fas fa-undo-alt"></i>',
-		callback: li => resetMovementHistory(ui.combat.viewed, li.data('combatant-id')),
-	};
-	menu.splice(1, 0, entry);
+  const entry = {
+    name: "drag-ruler.resetMovementHistory",
+    icon: '<i class="fas fa-undo-alt"></i>',
+    callback: li => resetMovementHistory(ui.combat.viewed, li.data('combatant-id')),
+  };
+  menu.splice(1, 0, entry);
 });
 
 Hooks.once('libRulerReady', async function() {
@@ -72,11 +72,11 @@ Hooks.once('libRulerReady', async function() {
 });
 
 function hookDragHandlers(entityType) {
-	const originalDragLeftStartHandler = entityType.prototype._onDragLeftStart
-	entityType.prototype._onDragLeftStart = function(event) {
-		originalDragLeftStartHandler.call(this, event)
-		onEntityLeftDragStart.call(this, event)
-	}
+  const originalDragLeftStartHandler = entityType.prototype._onDragLeftStart
+  entityType.prototype._onDragLeftStart = function(event) {
+    originalDragLeftStartHandler.call(this, event)
+    onEntityLeftDragStart.call(this, event)
+  }
 
 	const originalDragLeftMoveHandler = entityType.prototype._onDragLeftMove
 	entityType.prototype._onDragLeftMove = function (event) {
@@ -86,84 +86,84 @@ function hookDragHandlers(entityType) {
 		onEntityLeftDragMove.call(this, event)
 	}
 
-	const originalDragLeftDropHandler = entityType.prototype._onDragLeftDrop
-	entityType.prototype._onDragLeftDrop = function (event) {
-		const eventHandled = onEntityDragLeftDrop.call(this, event)
-		if (!eventHandled)
-			originalDragLeftDropHandler.call(this, event)
-	}
+  const originalDragLeftDropHandler = entityType.prototype._onDragLeftDrop
+  entityType.prototype._onDragLeftDrop = function (event) {
+    const eventHandled = onEntityDragLeftDrop.call(this, event)
+    if (!eventHandled)
+      originalDragLeftDropHandler.call(this, event)
+  }
 
-	const originalDragLeftCancelHandler = entityType.prototype._onDragLeftCancel
-	entityType.prototype._onDragLeftCancel = function (event) {
-		const eventHandled = onEntityDragLeftCancel.call(this, event)
-		if (!eventHandled)
-			originalDragLeftCancelHandler.call(this, event)
-	}
+  const originalDragLeftCancelHandler = entityType.prototype._onDragLeftCancel
+  entityType.prototype._onDragLeftCancel = function (event) {
+    const eventHandled = onEntityDragLeftCancel.call(this, event)
+    if (!eventHandled)
+      originalDragLeftCancelHandler.call(this, event)
+  }
 }
 
 function hookKeyboardManagerFunctions() {
-	const originalHandleKeys = KeyboardManager.prototype._handleKeys
-	KeyboardManager.prototype._handleKeys = function (event, key, up) {
-		const eventHandled = handleKeys.call(this, event, key, up)
-		if (!eventHandled)
-			originalHandleKeys.call(this, event, key, up)
-	}
+  const originalHandleKeys = KeyboardManager.prototype._handleKeys
+  KeyboardManager.prototype._handleKeys = function (event, key, up) {
+    const eventHandled = handleKeys.call(this, event, key, up)
+    if (!eventHandled)
+      originalHandleKeys.call(this, event, key, up)
+  }
 }
 
 function hookLayerFunctions() {
-	const originalTokenLayerUndoHistory = TokenLayer.prototype.undoHistory;
-	TokenLayer.prototype.undoHistory = function () {
-		const historyEntry = this.history[this.history.length - 1];
-		return originalTokenLayerUndoHistory.call(this).then((returnValue) => {
-			if (historyEntry.type === "update") {
-				for (const entry of historyEntry.data) {
-					const token = canvas.tokens.get(entry._id);
-					removeLastHistoryEntryIfAt(token, entry.x, entry.y);
-				}
-			}
-			return returnValue;
-		});
-	}
+  const originalTokenLayerUndoHistory = TokenLayer.prototype.undoHistory;
+  TokenLayer.prototype.undoHistory = function () {
+    const historyEntry = this.history[this.history.length - 1];
+    return originalTokenLayerUndoHistory.call(this).then((returnValue) => {
+      if (historyEntry.type === "update") {
+        for (const entry of historyEntry.data) {
+          const token = canvas.tokens.get(entry._id);
+          removeLastHistoryEntryIfAt(token, entry.x, entry.y);
+        }
+      }
+      return returnValue;
+    });
+  }
 }
 
 export function handleKeys(event, key, up) {
-	if (event.repeat || this.hasFocus)
-		return false
+  if (event.repeat || this.hasFocus)
+    return false
 
-	const lowercaseKey = key.toLowerCase();
+  const lowercaseKey = key.toLowerCase();
 
-	if (lowercaseKey === "x") return onKeyX(up)
-	if (lowercaseKey === "shift") return onKeyShift(up)
-	if (lowercaseKey === "space") return onKeySpace(up);
-	if (lowercaseKey === "escape") return onKeyEscape(up);
-	return false
+  if (lowercaseKey === "x") return onKeyX(up)
+  if (lowercaseKey === "shift") return onKeyShift(up)
+  if (lowercaseKey === "space") return onKeySpace(up);
+  if (lowercaseKey === "escape") return onKeyEscape(up);
+  return false
 }
 
 function onKeyX(up) {
-	if (up)
-		return false
-	const ruler = canvas.controls.ruler;
-	if (!ruler.isDragRuler)
-		return false
+  if (up)
+    return false
+  const ruler = canvas.controls.ruler;
+  if (!ruler.isDragRuler)
+    return false
 
-	ruler.dragRulerDeleteWaypoint();
-	return true
+  ruler.dragRulerDeleteWaypoint();
+  return true
 }
 
 function onKeyShift(up) {
-	const ruler = canvas.controls.ruler
-	if (!ruler.isDragRuler)
-		return false
-	if (ruler._state !== Ruler.STATES.MEASURING)
-		return false;
+  const ruler = canvas.controls.ruler
+  if (!ruler.isDragRuler)
+    return false
+  if (ruler._state !== Ruler.STATES.MEASURING)
+    return false;
 
-	const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens)
+  const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens)
         const rulerOffset = game.modules.get('libruler')?.active ? ruler.getFlag(settingsKey, "rulerOffset") : ruler.rulerOffset;
         const measurePosition = {x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y};
   if(game.modules.get('lib-wrapper')?.active) {
     ruler.setFlag(settingsKey, "snap", up);
   }
-	ruler.measure(measurePosition, {snap: up})
+  ruler.measure(measurePosition, {snap: up})
 }
 
 function onKeySpace(up) {
@@ -172,29 +172,29 @@ function onKeySpace(up) {
 	if (!ruler?.draggedEntity)
 		return false;
 
-	if (ruler._state !== Ruler.STATES.INACTIVE)
-		return false;
+  if (ruler._state !== Ruler.STATES.INACTIVE)
+    return false;
 
-	const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
-	let options = {};
-	setSnapParameterOnOptions(ruler, options);
+  const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
+  let options = {};
+  setSnapParameterOnOptions(ruler, options);
 
-	if (!up) {
-		if (swapSpacebarRightClick)
-			ruler.dragRulerAbortDrag();
-		else
-			startDragRuler.call(ruler.draggedEntity, options);
-	}
-	return true;
+  if (!up) {
+    if (swapSpacebarRightClick)
+      ruler.dragRulerAbortDrag();
+    else
+      startDragRuler.call(ruler.draggedEntity, options);
+  }
+  return true;
 }
 
 function onKeyEscape(up) {
-	const ruler = canvas.controls.ruler;
-	if (!ruler.draggedEntity)
-		return false;
-	if (!up)
-		ruler.dragRulerAbortDrag();
-	return true;
+  const ruler = canvas.controls.ruler;
+  if (!ruler.draggedEntity)
+    return false;
+  if (!up)
+    ruler.dragRulerAbortDrag();
+  return true;
 }
 
 function onEntityLeftDragStart(event) {
@@ -204,34 +204,34 @@ function onEntityLeftDragStart(event) {
 		return
 	const ruler = canvas.controls.ruler
 
-	if(game.modules.get('libruler')?.active) {
+  if(game.modules.get('libruler')?.active) {
     ruler.setFlag(settingsKey, "draggedEntityID", this.id);
-	} else {
-	  ruler.draggedEntity = this;
-	}
-	let entityCenter;
-	if (isToken && canvas.grid.isHex && game.modules.get("hex-size-support")?.active && CONFIG.hexSizeSupport.getAltSnappingFlag(this))
-		entityCenter = getHexSizeSupportTokenGridCenter(this);
-	else
-		entityCenter = this.center;
-	const rulerOffset = {x: entityCenter.x - event.data.origin.x, y: entityCenter.y - event.data.origin.y};
+  } else {
+    ruler.draggedEntity = this;
+  }
+  let entityCenter;
+  if (isToken && canvas.grid.isHex && game.modules.get("hex-size-support")?.active && CONFIG.hexSizeSupport.getAltSnappingFlag(this))
+    entityCenter = getHexSizeSupportTokenGridCenter(this);
+  else
+    entityCenter = this.center;
+  const rulerOffset = {x: entityCenter.x - event.data.origin.x, y: entityCenter.y - event.data.origin.y};
         if(game.modules.get('libruler')?.active) {
           ruler.setFlag(settingsKey, "rulerOffset", rulerOffset);
         } else {
           ruler.rulerOffset = rulerOffset;
         }
-	if (game.settings.get(settingsKey, "autoStartMeasurement")) {
-		let options = {};
-		setSnapParameterOnOptions(ruler, options);
-		startDragRuler.call(this, options, false);
-	}
+  if (game.settings.get(settingsKey, "autoStartMeasurement")) {
+    let options = {};
+    setSnapParameterOnOptions(ruler, options);
+    startDragRuler.call(this, options, false);
+  }
 }
 
 export function startDragRuler(options, measureImmediately=true) {
-	const isToken = this instanceof Token;
-	if (isToken && !currentSpeedProvider.usesRuler(this))
-		return;
-	const ruler = canvas.controls.ruler;
+  const isToken = this instanceof Token;
+  if (isToken && !currentSpeedProvider.usesRuler(this))
+    return;
+  const ruler = canvas.controls.ruler;
         // ruler.clear() call _endMeasurement and will wipe set flags.
         // but the flags may have already been set by onEntityLeftDragStart
         // so copy over
@@ -241,7 +241,7 @@ export function startDragRuler(options, measureImmediately=true) {
           draggedEntityID = ruler.getFlag(settingsKey, "draggedEntityID");
           rulerOffset = ruler.getFlag(settingsKey, "rulerOffset");
         }
-	ruler.clear();
+  ruler.clear();
 
         if(game.modules.get('libruler')?.active) {
           ruler.setFlag(settingsKey, "draggedEntityID", draggedEntityID);
@@ -274,6 +274,7 @@ export function startDragRuler(options, measureImmediately=true) {
           ruler._addWaypoint(entityCenter, false);
         } else {
 	ruler.dragRulerAddWaypoint(entityCenter, {snap: false});
+        }
 	const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
 
         rulerOffset = game.modules.get('libruler')?.active ? ruler.getFlag(settingsKey, "rulerOffset") : ruler.rulerOffset;
@@ -293,16 +294,16 @@ function onEntityLeftDragMove(event) {
           return onEntityLeftDragStart.call(this, event);
         }
 */
-	if (ruler.isDragRuler) {
-	  if(game.modules.get('libruler')?.active) {
-	    ruler._onMouseMove(event);
-	  } else {
-	    onMouseMove.call(ruler, event)
-	  }
-	}
+  if (ruler.isDragRuler) {
+    if(game.modules.get('libruler')?.active) {
+      ruler._onMouseMove(event);
+    } else {
+      onMouseMove.call(ruler, event)
+    }
+  }
 }
 
-function onEntityDragLeftDrop(event) {
+export function onEntityDragLeftDrop(event) {
   log(`onTokenDragLeftDrop`, event);
 	const ruler = canvas.controls.ruler
   log(`onTokenDragLeftDrop`, event, ruler);
@@ -318,43 +319,33 @@ function onEntityDragLeftDrop(event) {
 	if (selectedTokens.length === 0)
 		selectedTokens.push(ruler.draggedEntity);
 
-	if(game.modules.get('libruler')?.active) {
-	  ruler._onMouseMove(event);
-	} else {
-	  onMouseMove.call(ruler, event);
-	}
-
-
-	ruler._state = Ruler.STATES.MOVING
-	moveEntities.call(ruler, ruler.draggedEntity, selectedTokens);
-
-	if(game.modules.get('libruler')?.active) {
-	  ruler.moveToken();
-	} else {
-	  const selectedTokens = canvas.tokens.controlled
-	  moveTokens.call(ruler, ruler.draggedToken, selectedTokens)
-	}
-
-	return true
+  ruler._state = Ruler.STATES.MOVING
+  if(game.modules.get('libruler')?.active) {
+    ruler.moveToken();
+  } else {
+    const selectedTokens = canvas.tokens.controlled
+  moveEntities.call(ruler, ruler.draggedEntity, selectedTokens);
+  return true
+  }
 }
 
-function onEntityDragLeftCancel(event) {
+export function onEntityDragLeftCancel(event) {
   log(`onTokenDragLeftCancel`, event);
 	// This function is invoked by right clicking
-	const ruler = canvas.controls.ruler
   log(`onTokenDragLeftCancel ruler state ${ruler._state} `, event, ruler);
+	const ruler = canvas.controls.ruler
   log(`${ruler.waypoints.length} waypoints; waypoint[0] is ${ruler.waypoints[0]?.x}, ${ruler.waypoints[0]?.y}`, ruler.waypoints);
-	if (!ruler.draggedEntity || ruler._state === Ruler.STATES.MOVING) {
-         	return false
+  if (!ruler.draggedEntity || ruler._state === Ruler.STATES.MOVING) {
+          return false
         }
 
-	const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
-	let options = {};
-	setSnapParameterOnOptions(ruler, options);
+  const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
+  let options = {};
+  setSnapParameterOnOptions(ruler, options);
 
-	if (ruler._state === Ruler.STATES.INACTIVE) {
-		if (!swapSpacebarRightClick)
-			return false;
+  if (ruler._state === Ruler.STATES.INACTIVE) {
+    if (!swapSpacebarRightClick)
+      return false;
           log('Starting drag ruler');
 		startDragRuler.call(this, options);
 		event.preventDefault();
@@ -374,9 +365,9 @@ function onEntityDragLeftCancel(event) {
                           log('Adding waypoint (non-libruler version)');
 			ruler.dragRulerAddWaypoint(ruler.destination, options);
                         }
-		}
-	}
-	return true
+    }
+  }
+  return true
 }
 
 function applyGridlessSnapping(event) {
@@ -445,4 +436,28 @@ function applyGridlessSnapping(event) {
 			}
 		}
 	}
+export function getColorForDistance(startDistance, subDistance=0) {
+  if (!this.isDragRuler)
+    return this.color
+  if (!this.draggedEntity.actor) {
+    return this.color;
+  }
+  // Don't apply colors if the current user doesn't have at least observer permissions
+  if (this.draggedEntity.actor.permission < 2) {
+    // If this is a pc and alwaysShowSpeedForPCs is enabled we show the color anyway
+    if (!(this.draggedEntity.actor.data.type === "character" && game.settings.get(settingsKey, "alwaysShowSpeedForPCs")))
+      return this.color
+  }
+  const distance = startDistance + subDistance
+  if (!this.dragRulerRanges)
+    this.dragRulerRanges = getRangesFromSpeedProvider(this.draggedEntity);
+  const ranges = this.dragRulerRanges;
+  if (ranges.length === 0)
+    return this.color
+  const currentRange = ranges.reduce((minRange, currentRange) => {
+    if (distance <= currentRange.range && currentRange.range < minRange.range)
+      return currentRange
+    return minRange
+  }, {range: Infinity, color: getUnreachableColorFromSpeedProvider()})
+  return currentRange.color
 }

--- a/src/main.js
+++ b/src/main.js
@@ -206,6 +206,8 @@ function onEntityLeftDragStart(event) {
 	if (!currentSpeedProvider.usesRuler(this))
 		return
 	const ruler = canvas.controls.ruler
+  log(`onTokenLeftDragStart`, event, ruler);
+  log(`${ruler.waypoints.length} waypoints; waypoint[0] is ${ruler.waypoints[0]?.x}, ${ruler.waypoints[0]?.y}`, ruler.waypoints);
 
 	if(game.modules.get('libruler')?.active) {
     log(`token id is ${this.id}`, this);
@@ -267,6 +269,14 @@ function startDragRuler(options, measureImmediately=true) {
 function onEntityLeftDragMove(event) {
   log(`onTokenLeftDragMove`, event);
 	const ruler = canvas.controls.ruler
+  log(`onTokenLeftDragMove`, event, ruler);
+  log(`${ruler.waypoints.length} waypoints; waypoint[0] is ${ruler.waypoints[0]?.x}, ${ruler.waypoints[0]?.y}`, ruler.waypoints);
+
+        if(ruler.waypoints.length < 1) {
+          log(`No waypoints found; restarting.`);
+          return onTokenLeftDragStart(event);
+        }
+
 	if (ruler.isDragRuler) {
 	  if(game.modules.get('libruler')?.active) {
 	    ruler._onMouseMove(event);
@@ -279,6 +289,8 @@ function onEntityLeftDragMove(event) {
 function onEntityDragLeftDrop(event) {
   log(`onTokenDragLeftDrop`, event);
 	const ruler = canvas.controls.ruler
+  log(`onTokenDragLeftDrop`, event, ruler);
+  log(`${ruler.waypoints.length} waypoints; waypoint[0] is ${ruler.waypoints[0]?.x}, ${ruler.waypoints[0]?.y}`, ruler.waypoints);
 	if (!ruler.isDragRuler) {
 		ruler.draggedEntity = undefined;
 		return false
@@ -314,6 +326,8 @@ function onEntityDragLeftCancel(event) {
   log(`onTokenDragLeftCancel`, event);
 	// This function is invoked by right clicking
 	const ruler = canvas.controls.ruler
+  log(`onTokenDragLeftCancel`, event, ruler);
+  log(`${ruler.waypoints.length} waypoints; waypoint[0] is ${ruler.waypoints[0]?.x}, ${ruler.waypoints[0]?.y}`, ruler.waypoints);
 	if (!ruler.draggedEntity || ruler._state === Ruler.STATES.MOVING)
 		return false
 
@@ -332,8 +346,14 @@ function onEntityDragLeftCancel(event) {
 			ruler.dragRulerDeleteWaypoint(event, options);
 		}
 		else {
+                        log(`Adding waypoint at ${ruler.destination.x}, ${ruler.destination.y}`);
 			event.preventDefault();
+			const snap = !event.shiftKey
+                        if(game.modules.get('libruler')?.active) { 
+                          ruler._addWaypoint(ruler.destination, snap);
+                        } else {
 			ruler.dragRulerAddWaypoint(ruler.destination, options);
+                        }
 		}
 	}
 	return true

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,6 @@ import {SpeedProvider} from "./speed_provider.js"
 import {registerLibWrapper, MODULE_ID} from "./libwrapper.js"
 import {isClose, setSnapParameterOnOptions} from "./util.js";
 import {registerLibRuler, log} from "./libruler.js"
-import {isClose, setSnapParameterOnOptions} from "./util.js";
 
 Hooks.once("init", () => {
 	registerSettings()
@@ -45,16 +44,15 @@ Hooks.once("ready", () => {
 })
 
 Hooks.on("canvasReady", () => {
-  if(!game.modules.get('libruler')?.active)) {
-	canvas.controls.rulers.children.forEach(ruler => {
-		ruler.draggedEntity = null;
-		Object.defineProperty(ruler, "isDragRuler", {
-			get: function isDragRuler() {
-				return Boolean(this.draggedEntity) && this._state !== Ruler.STATES.INACTIVE;
-			}
+  if(!game.modules.get('libruler')?.active) {
+		canvas.controls.rulers.children.forEach(ruler => {
+			ruler.draggedEntity = null;
+			Object.defineProperty(ruler, "isDragRuler", {
+				get: function isDragRuler() {
+					return Boolean(this.draggedEntity) && this._state !== Ruler.STATES.INACTIVE;
+				}
 			})
 		})
-	})
   }
 });
 
@@ -230,24 +228,23 @@ export function onEntityLeftDragStart(event) {
 
 export function startDragRuler(options, measureImmediately=true) {
 	const isToken = this instanceof Token;
-	if (isToken && !currentSpeedProvider.usesRuler(this))
-		return;
+	if (isToken && !currentSpeedProvider.usesRuler(this)) return;
 	const ruler = canvas.controls.ruler;
-				// ruler.clear() call _endMeasurement and will wipe set flags.
-				// but the flags may have already been set by onEntityLeftDragStart
-				// so copy over
-				let draggedEntityID;
-				let rulerOffset;
-				if(game.modules.get('libruler')?.active) {
-					draggedEntityID = ruler.getFlag(settingsKey, "draggedEntityID");
-					rulerOffset = ruler.getFlag(settingsKey, "rulerOffset");
-				}
+	// ruler.clear() call _endMeasurement and will wipe set flags.
+	// but the flags may have already been set by onEntityLeftDragStart
+	// so copy over
+	let draggedEntityID;
+	let rulerOffset;
+	if(game.modules.get('libruler')?.active) {
+		draggedEntityID = ruler.getFlag(settingsKey, "draggedEntityID");
+		rulerOffset = ruler.getFlag(settingsKey, "rulerOffset");
+	}
 	ruler.clear();
 
-				if(game.modules.get('libruler')?.active) {
-					ruler.setFlag(settingsKey, "draggedEntityID", draggedEntityID);
-					ruler.setFlag(settingsKey, "rulerOffset", rulerOffset);
-				}
+	if(game.modules.get('libruler')?.active) {
+		ruler.setFlag(settingsKey, "draggedEntityID", draggedEntityID);
+		ruler.setFlag(settingsKey, "rulerOffset", rulerOffset);
+	}
 	ruler._state = Ruler.STATES.STARTING;
 	const rulerOffset = {x: tokenCenter.x - event.data.origin.x, y: tokenCenter.y - event.data.origin.y}
 	if(game.modules.get('libruler')?.active) {
@@ -349,7 +346,7 @@ export function onEntityDragLeftCancel(event) {
                         log(`Adding waypoint at ${ruler.destination.x}, ${ruler.destination.y}`);
 			event.preventDefault();
 			const snap = !event.shiftKey
-                        if(game.modules.get('libruler')?.active) { 
+                        if(game.modules.get('libruler')?.active) {
                           log('Adding waypoint');
                           ruler._addWaypoint(ruler.destination, Boolean(options.snap));
                         } else {

--- a/src/main.js
+++ b/src/main.js
@@ -15,18 +15,18 @@ import {registerLibRuler, log} from "./libruler.js"
 import {isClose, setSnapParameterOnOptions} from "./util.js";
 
 Hooks.once("init", () => {
-  registerSettings()
-  initApi()
-  hookLayerFunctions();
+	registerSettings()
+	initApi()
+	hookLayerFunctions();
 
-        if(!game.modules.get('lib-wrapper')?.active) {
-    hookDragHandlers(Token)
-          hookDragHandlers(MeasuredTemplate);
-    hookKeyboardManagerFunctions()
-        } else {
-          registerLibWrapper();
-        }
-  if(!game.modules.get('libruler')?.active) Ruler = DragRulerRuler;
+				if(!game.modules.get('lib-wrapper')?.active) {
+		hookDragHandlers(Token)
+					hookDragHandlers(MeasuredTemplate);
+		hookKeyboardManagerFunctions()
+				} else {
+					registerLibWrapper();
+				}
+	if(!game.modules.get('libruler')?.active) Ruler = DragRulerRuler;
 
 	window.dragRuler = {
 		getColorForDistanceAndToken,
@@ -39,9 +39,9 @@ Hooks.once("init", () => {
 })
 
 Hooks.once("ready", () => {
-  performMigrations()
-  checkDependencies();
-  Hooks.callAll("dragRuler.ready", SpeedProvider)
+	performMigrations()
+	checkDependencies();
+	Hooks.callAll("dragRuler.ready", SpeedProvider)
 })
 
 Hooks.on("canvasReady", () => {
@@ -59,24 +59,24 @@ Hooks.on("canvasReady", () => {
 });
 
 Hooks.on("getCombatTrackerEntryContext", function (html, menu) {
-  const entry = {
-    name: "drag-ruler.resetMovementHistory",
-    icon: '<i class="fas fa-undo-alt"></i>',
-    callback: li => resetMovementHistory(ui.combat.viewed, li.data('combatant-id')),
-  };
-  menu.splice(1, 0, entry);
+	const entry = {
+		name: "drag-ruler.resetMovementHistory",
+		icon: '<i class="fas fa-undo-alt"></i>',
+		callback: li => resetMovementHistory(ui.combat.viewed, li.data('combatant-id')),
+	};
+	menu.splice(1, 0, entry);
 });
 
 Hooks.once('libRulerReady', async function() {
-  registerLibRuler();
+	registerLibRuler();
 });
 
 function hookDragHandlers(entityType) {
-  const originalDragLeftStartHandler = entityType.prototype._onDragLeftStart
-  entityType.prototype._onDragLeftStart = function(event) {
-    originalDragLeftStartHandler.call(this, event)
-    onEntityLeftDragStart.call(this, event)
-  }
+	const originalDragLeftStartHandler = entityType.prototype._onDragLeftStart
+	entityType.prototype._onDragLeftStart = function(event) {
+		originalDragLeftStartHandler.call(this, event)
+		onEntityLeftDragStart.call(this, event)
+	}
 
 	const originalDragLeftMoveHandler = entityType.prototype._onDragLeftMove
 	entityType.prototype._onDragLeftMove = function (event) {
@@ -86,84 +86,84 @@ function hookDragHandlers(entityType) {
 		onEntityLeftDragMove.call(this, event)
 	}
 
-  const originalDragLeftDropHandler = entityType.prototype._onDragLeftDrop
-  entityType.prototype._onDragLeftDrop = function (event) {
-    const eventHandled = onEntityDragLeftDrop.call(this, event)
-    if (!eventHandled)
-      originalDragLeftDropHandler.call(this, event)
-  }
+	const originalDragLeftDropHandler = entityType.prototype._onDragLeftDrop
+	entityType.prototype._onDragLeftDrop = function (event) {
+		const eventHandled = onEntityDragLeftDrop.call(this, event)
+		if (!eventHandled)
+			originalDragLeftDropHandler.call(this, event)
+	}
 
-  const originalDragLeftCancelHandler = entityType.prototype._onDragLeftCancel
-  entityType.prototype._onDragLeftCancel = function (event) {
-    const eventHandled = onEntityDragLeftCancel.call(this, event)
-    if (!eventHandled)
-      originalDragLeftCancelHandler.call(this, event)
-  }
+	const originalDragLeftCancelHandler = entityType.prototype._onDragLeftCancel
+	entityType.prototype._onDragLeftCancel = function (event) {
+		const eventHandled = onEntityDragLeftCancel.call(this, event)
+		if (!eventHandled)
+			originalDragLeftCancelHandler.call(this, event)
+	}
 }
 
 function hookKeyboardManagerFunctions() {
-  const originalHandleKeys = KeyboardManager.prototype._handleKeys
-  KeyboardManager.prototype._handleKeys = function (event, key, up) {
-    const eventHandled = handleKeys.call(this, event, key, up)
-    if (!eventHandled)
-      originalHandleKeys.call(this, event, key, up)
-  }
+	const originalHandleKeys = KeyboardManager.prototype._handleKeys
+	KeyboardManager.prototype._handleKeys = function (event, key, up) {
+		const eventHandled = handleKeys.call(this, event, key, up)
+		if (!eventHandled)
+			originalHandleKeys.call(this, event, key, up)
+	}
 }
 
 function hookLayerFunctions() {
-  const originalTokenLayerUndoHistory = TokenLayer.prototype.undoHistory;
-  TokenLayer.prototype.undoHistory = function () {
-    const historyEntry = this.history[this.history.length - 1];
-    return originalTokenLayerUndoHistory.call(this).then((returnValue) => {
-      if (historyEntry.type === "update") {
-        for (const entry of historyEntry.data) {
-          const token = canvas.tokens.get(entry._id);
-          removeLastHistoryEntryIfAt(token, entry.x, entry.y);
-        }
-      }
-      return returnValue;
-    });
-  }
+	const originalTokenLayerUndoHistory = TokenLayer.prototype.undoHistory;
+	TokenLayer.prototype.undoHistory = function () {
+		const historyEntry = this.history[this.history.length - 1];
+		return originalTokenLayerUndoHistory.call(this).then((returnValue) => {
+			if (historyEntry.type === "update") {
+				for (const entry of historyEntry.data) {
+					const token = canvas.tokens.get(entry._id);
+					removeLastHistoryEntryIfAt(token, entry.x, entry.y);
+				}
+			}
+			return returnValue;
+		});
+	}
 }
 
 export function handleKeys(event, key, up) {
-  if (event.repeat || this.hasFocus)
-    return false
+	if (event.repeat || this.hasFocus)
+		return false
 
-  const lowercaseKey = key.toLowerCase();
+	const lowercaseKey = key.toLowerCase();
 
-  if (lowercaseKey === "x") return onKeyX(up)
-  if (lowercaseKey === "shift") return onKeyShift(up)
-  if (lowercaseKey === "space") return onKeySpace(up);
-  if (lowercaseKey === "escape") return onKeyEscape(up);
-  return false
+	if (lowercaseKey === "x") return onKeyX(up)
+	if (lowercaseKey === "shift") return onKeyShift(up)
+	if (lowercaseKey === "space") return onKeySpace(up);
+	if (lowercaseKey === "escape") return onKeyEscape(up);
+	return false
 }
 
 function onKeyX(up) {
-  if (up)
-    return false
-  const ruler = canvas.controls.ruler;
-  if (!ruler.isDragRuler)
-    return false
+	if (up)
+		return false
+	const ruler = canvas.controls.ruler;
+	if (!ruler.isDragRuler)
+		return false
 
-  ruler.dragRulerDeleteWaypoint();
-  return true
+	ruler.dragRulerDeleteWaypoint();
+	return true
 }
 
 function onKeyShift(up) {
-  const ruler = canvas.controls.ruler
-  if (!ruler.isDragRuler)
-    return false
-  if (ruler._state !== Ruler.STATES.MEASURING)
-    return false;
+	const ruler = canvas.controls.ruler
+	if (!ruler.isDragRuler)
+		return false
+	if (ruler._state !== Ruler.STATES.MEASURING)
+		return false;
 
-  const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens)
-        const rulerOffset = game.modules.get('libruler')?.active ? ruler.getFlag(settingsKey, "rulerOffset") : ruler.rulerOffset;
-        const measurePosition = {x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y};
-  if(game.modules.get('lib-wrapper')?.active) {
-    ruler.setFlag(settingsKey, "snap", up);
-  }
-  ruler.measure(measurePosition, {snap: up})
+	const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens)
+				const rulerOffset = game.modules.get('libruler')?.active ? ruler.getFlag(settingsKey, "rulerOffset") : ruler.rulerOffset;
+				const measurePosition = {x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y};
+	if(game.modules.get('lib-wrapper')?.active) {
+		ruler.setFlag(settingsKey, "snap", up);
+	}
+	ruler.measure(measurePosition, {snap: up})
 }
 
 function onKeySpace(up) {
@@ -172,96 +172,94 @@ function onKeySpace(up) {
 	if (!ruler?.draggedEntity)
 		return false;
 
-  if (ruler._state !== Ruler.STATES.INACTIVE)
-    return false;
+	if (ruler._state !== Ruler.STATES.INACTIVE)
+		return false;
 
-  const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
-  let options = {};
-  setSnapParameterOnOptions(ruler, options);
+	const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
+	let options = {};
+	setSnapParameterOnOptions(ruler, options);
 
-  if (!up) {
-    if (swapSpacebarRightClick)
-      ruler.dragRulerAbortDrag();
-    else
-      startDragRuler.call(ruler.draggedEntity, options);
-  }
-  return true;
+	if (!up) {
+		if (swapSpacebarRightClick)
+			ruler.dragRulerAbortDrag();
+		else
+			startDragRuler.call(ruler.draggedEntity, options);
+	}
+	return true;
 }
 
 function onKeyEscape(up) {
-  const ruler = canvas.controls.ruler;
-  if (!ruler.draggedEntity)
-    return false;
-  if (!up)
-    ruler.dragRulerAbortDrag();
-  return true;
+	const ruler = canvas.controls.ruler;
+	if (!ruler.draggedEntity)
+		return false;
+	if (!up)
+		ruler.dragRulerAbortDrag();
+	return true;
 }
 
-function onEntityLeftDragStart(event) {
+export function onEntityLeftDragStart(event) {
   log(`onTokenLeftDragStart`, event);
 	const isToken = this instanceof Token;
 	if (!currentSpeedProvider.usesRuler(this))
 		return
 	const ruler = canvas.controls.ruler
 
-  if(game.modules.get('libruler')?.active) {
-    ruler.setFlag(settingsKey, "draggedEntityID", this.id);
-  } else {
-    ruler.draggedEntity = this;
-  }
-  let entityCenter;
-  if (isToken && canvas.grid.isHex && game.modules.get("hex-size-support")?.active && CONFIG.hexSizeSupport.getAltSnappingFlag(this))
-    entityCenter = getHexSizeSupportTokenGridCenter(this);
-  else
-    entityCenter = this.center;
-  const rulerOffset = {x: entityCenter.x - event.data.origin.x, y: entityCenter.y - event.data.origin.y};
-        if(game.modules.get('libruler')?.active) {
-          ruler.setFlag(settingsKey, "rulerOffset", rulerOffset);
-        } else {
-          ruler.rulerOffset = rulerOffset;
-        }
-  if (game.settings.get(settingsKey, "autoStartMeasurement")) {
-    let options = {};
-    setSnapParameterOnOptions(ruler, options);
-    startDragRuler.call(this, options, false);
-  }
+	if(game.modules.get('libruler')?.active) {
+		ruler.setFlag(settingsKey, "draggedEntityID", this.id);
+	} else {
+		ruler.draggedEntity = this;
+	}
+	let entityCenter;
+	if (isToken && canvas.grid.isHex && game.modules.get("hex-size-support")?.active && CONFIG.hexSizeSupport.getAltSnappingFlag(this))
+		entityCenter = getHexSizeSupportTokenGridCenter(this);
+	else
+		entityCenter = this.center;
+	const rulerOffset = {x: entityCenter.x - event.data.origin.x, y: entityCenter.y - event.data.origin.y};
+				if(game.modules.get('libruler')?.active) {
+					ruler.setFlag(settingsKey, "rulerOffset", rulerOffset);
+				} else {
+					ruler.rulerOffset = rulerOffset;
+				}
+	if (game.settings.get(settingsKey, "autoStartMeasurement")) {
+		let options = {};
+		setSnapParameterOnOptions(ruler, options);
+		startDragRuler.call(this, options, false);
+	}
 }
 
 export function startDragRuler(options, measureImmediately=true) {
-  const isToken = this instanceof Token;
-  if (isToken && !currentSpeedProvider.usesRuler(this))
-    return;
-  const ruler = canvas.controls.ruler;
-        // ruler.clear() call _endMeasurement and will wipe set flags.
-        // but the flags may have already been set by onEntityLeftDragStart
-        // so copy over
-        let draggedEntityID;
-        let rulerOffset;
-        if(game.modules.get('libruler')?.active) {
-          draggedEntityID = ruler.getFlag(settingsKey, "draggedEntityID");
-          rulerOffset = ruler.getFlag(settingsKey, "rulerOffset");
-        }
-  ruler.clear();
+	const isToken = this instanceof Token;
+	if (isToken && !currentSpeedProvider.usesRuler(this))
+		return;
+	const ruler = canvas.controls.ruler;
+				// ruler.clear() call _endMeasurement and will wipe set flags.
+				// but the flags may have already been set by onEntityLeftDragStart
+				// so copy over
+				let draggedEntityID;
+				let rulerOffset;
+				if(game.modules.get('libruler')?.active) {
+					draggedEntityID = ruler.getFlag(settingsKey, "draggedEntityID");
+					rulerOffset = ruler.getFlag(settingsKey, "rulerOffset");
+				}
+	ruler.clear();
 
-        if(game.modules.get('libruler')?.active) {
-          ruler.setFlag(settingsKey, "draggedEntityID", draggedEntityID);
-          ruler.setFlag(settingsKey, "rulerOffset", rulerOffset);
-        }
+				if(game.modules.get('libruler')?.active) {
+					ruler.setFlag(settingsKey, "draggedEntityID", draggedEntityID);
+					ruler.setFlag(settingsKey, "rulerOffset", rulerOffset);
+				}
 	ruler._state = Ruler.STATES.STARTING;
-
 	const rulerOffset = {x: tokenCenter.x - event.data.origin.x, y: tokenCenter.y - event.data.origin.y}
 	if(game.modules.get('libruler')?.active) {
 	  ruler.setFlag(MODULE_ID, "rulerOffset", rulerOffset);
 	} else {
 	  ruler.rulerOffset = rulerOffset
 	}
-
-
 	if (game.settings.get(settingsKey, "enableMovementHistory"))
 		ruler.dragRulerAddWaypointHistory(getMovementHistory(this))
 
         if(game.modules.get('libruler')?.active) {
           ruler._addWaypoint(tokenCenter, false);
+
         } else {
 	let entityCenter;
 	if (isToken && canvas.grid.isHex && game.modules.get("hex-size-support")?.active && CONFIG.hexSizeSupport.getAltSnappingFlag(this))
@@ -281,18 +279,17 @@ export function startDragRuler(options, measureImmediately=true) {
 	const destination = {x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y};
 	if (measureImmediately)
 		ruler.measure(destination, options);
-        }
 }
 
 function onEntityLeftDragMove(event) {
   log(`onTokenLeftDragMove`, event);
 	const ruler = canvas.controls.ruler
 	if (ruler.isDragRuler) {
-	  if(game.modules.get('libruler')?.active) {
-	    ruler._onMouseMove(event);
-	  } else {
-	    onMouseMove.call(ruler, event)
-	  }
+		if(game.modules.get('libruler')?.active) {
+			ruler._onMouseMove(event);
+		} else {
+			onMouseMove.call(ruler, event)
+		}
 	}
 }
 
@@ -318,8 +315,8 @@ export function onEntityDragLeftDrop(event) {
   } else {
     const selectedTokens = canvas.tokens.controlled
   moveEntities.call(ruler, ruler.draggedEntity, selectedTokens);
-  return true
-  }
+	return true
+	}
 }
 
 export function onEntityDragLeftCancel(event) {
@@ -332,9 +329,9 @@ export function onEntityDragLeftCancel(event) {
           return false
         }
 
-  const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
-  let options = {};
-  setSnapParameterOnOptions(ruler, options);
+	const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
+	let options = {};
+	setSnapParameterOnOptions(ruler, options);
 
 	if (ruler._state === Ruler.STATES.INACTIVE) {
 		if (!swapSpacebarRightClick)
@@ -430,27 +427,27 @@ function applyGridlessSnapping(event) {
 		}
 	}
 export function getColorForDistance(startDistance, subDistance=0) {
-  if (!this.isDragRuler)
-    return this.color
-  if (!this.draggedEntity.actor) {
-    return this.color;
-  }
-  // Don't apply colors if the current user doesn't have at least observer permissions
-  if (this.draggedEntity.actor.permission < 2) {
-    // If this is a pc and alwaysShowSpeedForPCs is enabled we show the color anyway
-    if (!(this.draggedEntity.actor.data.type === "character" && game.settings.get(settingsKey, "alwaysShowSpeedForPCs")))
-      return this.color
-  }
-  const distance = startDistance + subDistance
-  if (!this.dragRulerRanges)
-    this.dragRulerRanges = getRangesFromSpeedProvider(this.draggedEntity);
-  const ranges = this.dragRulerRanges;
-  if (ranges.length === 0)
-    return this.color
-  const currentRange = ranges.reduce((minRange, currentRange) => {
-    if (distance <= currentRange.range && currentRange.range < minRange.range)
-      return currentRange
-    return minRange
-  }, {range: Infinity, color: getUnreachableColorFromSpeedProvider()})
-  return currentRange.color
+	if (!this.isDragRuler)
+		return this.color
+	if (!this.draggedEntity.actor) {
+		return this.color;
+	}
+	// Don't apply colors if the current user doesn't have at least observer permissions
+	if (this.draggedEntity.actor.permission < 2) {
+		// If this is a pc and alwaysShowSpeedForPCs is enabled we show the color anyway
+		if (!(this.draggedEntity.actor.data.type === "character" && game.settings.get(settingsKey, "alwaysShowSpeedForPCs")))
+			return this.color
+	}
+	const distance = startDistance + subDistance
+	if (!this.dragRulerRanges)
+		this.dragRulerRanges = getRangesFromSpeedProvider(this.draggedEntity);
+	const ranges = this.dragRulerRanges;
+	if (ranges.length === 0)
+		return this.color
+	const currentRange = ranges.reduce((minRange, currentRange) => {
+		if (distance <= currentRange.range && currentRange.range < minRange.range)
+			return currentRange
+		return minRange
+	}, {range: Infinity, color: getUnreachableColorFromSpeedProvider()})
+	return currentRange.color
 }

--- a/src/main.js
+++ b/src/main.js
@@ -102,11 +102,11 @@ function hookDragHandlers(entityType) {
 }
 
 function hookKeyboardManagerFunctions() {
-	const originalHandleKeys = KeyboardManager.prototype._handleKeys
-	KeyboardManager.prototype._handleKeys = function (event, key, up) {
-		const eventHandled = handleKeys.call(this, event, key, up)
+	const originalHandleKeys = KeyboardManager.prototype._handleKeyboardEvent(event, up)
+	KeyboardManager.prototype._handleKeys = function (event, up) {
+		const eventHandled = handleKeys.call(this, event, up)
 		if (!eventHandled)
-			originalHandleKeys.call(this, event, key, up)
+			originalHandleKeys.call(this, event, up)
 	}
 }
 
@@ -126,11 +126,12 @@ function hookLayerFunctions() {
 	}
 }
 
-export function handleKeys(event, key, up) {
+export function handleKeys(event, up) {
 	if (event.repeat || this.hasFocus)
 		return false
 
-	const lowercaseKey = key.toLowerCase();
+  const context = KeyboardManager.getKeyboardEventContext(event, up);
+	const lowercaseKey = context.key.toLowerCase();
 
 	if (lowercaseKey === "x") return onKeyX(up)
 	if (lowercaseKey === "shift") return onKeyShift(up)

--- a/src/main.js
+++ b/src/main.js
@@ -321,6 +321,7 @@ function onEntityDragLeftDrop(event) {
 	moveEntities.call(ruler, ruler.draggedEntity, selectedTokens);
 
 	if(game.modules.get('libruler')?.active) {
+	  ruler.setFlag(MODULE_ID, "doTokenMove", true);
 	  ruler.moveToken();
 	} else {
 	  const selectedTokens = canvas.tokens.controlled

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import {registerSettings, settingsKey} from "./settings.js"
 import {recalculate} from "./socket.js";
 import {SpeedProvider} from "./speed_provider.js"
 import {registerLibWrapper, MODULE_ID} from "./libwrapper.js"
+import {isClose, setSnapParameterOnOptions} from "./util.js";
 import {registerLibRuler, log} from "./libruler.js"
 import {isClose, setSnapParameterOnOptions} from "./util.js";
 
@@ -159,10 +160,10 @@ function onKeyShift(up) {
 		return false;
 
 	const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens)
-        const rulerOffset = game.modules.get('libruler')?.active ? ruler.getFlag(MODULE_ID, "rulerOffset") : ruler.rulerOffset;
+        const rulerOffset = game.modules.get('libruler')?.active ? ruler.getFlag(settingsKey, "rulerOffset") : ruler.rulerOffset;
         const measurePosition = {x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y};
   if(game.modules.get('lib-wrapper')?.active) {
-    ruler.setFlag(MODULE_ID, "snap", up);
+    ruler.setFlag(settingsKey, "snap", up);
   }
 	ruler.measure(measurePosition, {snap: up})
 }
@@ -209,7 +210,7 @@ function onEntityLeftDragStart(event) {
 
 	if(game.modules.get('libruler')?.active) {
     log(`token id is ${this.id}`, this);
-    ruler.setFlag(MODULE_ID, "draggedTokenID", this.id);
+    ruler.setFlag(settingsKey, "draggedTokenID", this.id);
     log(`Set draggedTokenID. Ruler isDragRuler? ${ruler.isDragRuler}`, ruler);
 	} else {
 	ruler.draggedEntity = this;
@@ -221,7 +222,7 @@ function onEntityLeftDragStart(event) {
 		entityCenter = this.center;
 	const rulerOffset = {x: entityCenter.x - event.data.origin.x, y: entityCenter.y - event.data.origin.y};
         if(game.modules.get('libruler')?.active) {
-          ruler.setFlag(MODULE_ID, "rulerOffset", rulerOffset);
+          ruler.setFlag(settingsKey, "rulerOffset", rulerOffset);
         } else {
           ruler.rulerOffset = rulerOffset;
         }
@@ -267,7 +268,7 @@ export function startDragRuler(options, measureImmediately=true) {
 	ruler.dragRulerAddWaypoint(entityCenter, {snap: false});
 	const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
 
-        const rulerOffset = game.modules.get('libruler')?.active ? ruler.getFlag(MODULE_ID, "rulerOffset") : ruler.rulerOffset;
+        const rulerOffset = game.modules.get('libruler')?.active ? ruler.getFlag(settingsKey, "rulerOffset") : ruler.rulerOffset;
 	const destination = {x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y};
 	if (measureImmediately)
 		ruler.measure(destination, options);
@@ -321,7 +322,7 @@ function onEntityDragLeftDrop(event) {
 	moveEntities.call(ruler, ruler.draggedEntity, selectedTokens);
 
 	if(game.modules.get('libruler')?.active) {
-	  ruler.setFlag(MODULE_ID, "doTokenMove", true);
+	  ruler.setFlag(settingsKey, "doTokenMove", true);
 	  ruler.moveToken();
 	} else {
 	  const selectedTokens = canvas.tokens.controlled

--- a/src/main.js
+++ b/src/main.js
@@ -140,7 +140,6 @@ export function handleKeys(event, key, up) {
 }
 
 function onKeyX(up) {
-  log(`onKeyX ${up}`);
 	if (up)
 		return false
 	const ruler = canvas.controls.ruler;
@@ -152,7 +151,6 @@ function onKeyX(up) {
 }
 
 function onKeyShift(up) {
-  log(`onKeyShift ${up}`);
 	const ruler = canvas.controls.ruler
 	if (!ruler.isDragRuler)
 		return false
@@ -205,15 +203,11 @@ function onEntityLeftDragStart(event) {
 	if (!currentSpeedProvider.usesRuler(this))
 		return
 	const ruler = canvas.controls.ruler
-  log(`onTokenLeftDragStart`, event, ruler);
-  log(`${ruler.waypoints.length} waypoints; waypoint[0] is ${ruler.waypoints[0]?.x}, ${ruler.waypoints[0]?.y}`, ruler.waypoints);
 
 	if(game.modules.get('libruler')?.active) {
-    log(`token id is ${this.id}`, this);
     ruler.setFlag(settingsKey, "draggedEntityID", this.id);
-    log(`Set draggedEntityID. Ruler isDragRuler? ${ruler.isDragRuler}`, ruler);
 	} else {
-	ruler.draggedEntity = this;
+	  ruler.draggedEntity = this;
 	}
 	let entityCenter;
 	if (isToken && canvas.grid.isHex && game.modules.get("hex-size-support")?.active && CONFIG.hexSizeSupport.getAltSnappingFlag(this))
@@ -292,8 +286,6 @@ export function startDragRuler(options, measureImmediately=true) {
 function onEntityLeftDragMove(event) {
   log(`onTokenLeftDragMove`, event);
 	const ruler = canvas.controls.ruler
-  log(`onTokenLeftDragMove`, event, ruler);
-  log(`${ruler.waypoints.length} waypoints; waypoint[0] is ${ruler.waypoints[0]?.x}, ${ruler.waypoints[0]?.y}`, ruler.waypoints);
 
 /*
         if(ruler.waypoints.length < 1) {
@@ -353,17 +345,14 @@ function onEntityDragLeftCancel(event) {
   log(`onTokenDragLeftCancel ruler state ${ruler._state} `, event, ruler);
   log(`${ruler.waypoints.length} waypoints; waypoint[0] is ${ruler.waypoints[0]?.x}, ${ruler.waypoints[0]?.y}`, ruler.waypoints);
 	if (!ruler.draggedEntity || ruler._state === Ruler.STATES.MOVING) {
-	  log('returning false from dragLeftCancel');
          	return false
         }
 
 	const swapSpacebarRightClick = game.settings.get(settingsKey, "swapSpacebarRightClick");
 	let options = {};
-        log('setting snap');
 	setSnapParameterOnOptions(ruler, options);
 
 	if (ruler._state === Ruler.STATES.INACTIVE) {
-          log('Ruler state inactive.');
 		if (!swapSpacebarRightClick)
 			return false;
           log('Starting drag ruler');
@@ -371,9 +360,7 @@ function onEntityDragLeftCancel(event) {
 		event.preventDefault();
 	}
 	else if (ruler._state === Ruler.STATES.MEASURING) {
-          log('Ruler state measuring');
 		if (!swapSpacebarRightClick) {
-                   log('Deleting waypoint');
 			ruler.dragRulerDeleteWaypoint(event, options);
 		}
 		else {

--- a/src/ruler.js
+++ b/src/ruler.js
@@ -21,6 +21,7 @@ export class DragRulerRuler extends Ruler {
 	}
 
 	async moveToken(event) {
+          console.log(`drag-ruler|moveToken`, this);
 		// This function is invoked by left clicking
 		if (!this.isDragRuler)
 			return await super.moveToken(event);

--- a/src/ruler.js
+++ b/src/ruler.js
@@ -5,162 +5,162 @@ import {settingsKey} from "./settings.js";
 import {getSnapPointForEntity, setSnapParameterOnOptions} from "./util.js";
 
 export class DragRulerRuler extends Ruler {
-  // Functions below are overridden versions of functions in Ruler
-  constructor(user, {color=null}={}) {
-    super(user, {color});
-    this.previousWaypoints = [];
-    this.previousLabels = this.addChild(new PIXI.Container());
-  }
+	// Functions below are overridden versions of functions in Ruler
+	constructor(user, {color=null}={}) {
+		super(user, {color});
+		this.previousWaypoints = [];
+		this.previousLabels = this.addChild(new PIXI.Container());
+	}
 
-  clear() {
-    super.clear();
-    this.previousWaypoints = [];
-    this.previousLabels.removeChildren().forEach(c => c.destroy());
-    this.dragRulerRanges = undefined;
-    cancelScheduledMeasurement.call(this);
-  }
+	clear() {
+		super.clear();
+		this.previousWaypoints = [];
+		this.previousLabels.removeChildren().forEach(c => c.destroy());
+		this.dragRulerRanges = undefined;
+		cancelScheduledMeasurement.call(this);
+	}
 
-  async moveToken(event) {
-          console.log(`drag-ruler|moveToken`, this);
-    // This function is invoked by left clicking
-    if (!this.isDragRuler)
-      return await super.moveToken(event);
+	async moveToken(event) {
+					console.log(`drag-ruler|moveToken`, this);
+		// This function is invoked by left clicking
+		if (!this.isDragRuler)
+			return await super.moveToken(event);
 
-    let options = {};
-    setSnapParameterOnOptions(this, options);
+		let options = {};
+		setSnapParameterOnOptions(this, options);
 
-    if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
-      this.dragRulerAddWaypoint(this.destination, options);
-    }
-    else {
-      this.dragRulerDeleteWaypoint(event, options);
-    }
-  }
+		if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
+			this.dragRulerAddWaypoint(this.destination, options);
+		}
+		else {
+			this.dragRulerDeleteWaypoint(event, options);
+		}
+	}
 
-  toJSON() {
-    const json = super.toJSON();
-    if (this.draggedEntity) {
-      const isToken = this.draggedEntity instanceof Token;
-      json["draggedEntityIsToken"] = isToken;
-      json["draggedEntity"] = this.draggedEntity.id;
-    }
-    return json;
-  }
+	toJSON() {
+		const json = super.toJSON();
+		if (this.draggedEntity) {
+			const isToken = this.draggedEntity instanceof Token;
+			json["draggedEntityIsToken"] = isToken;
+			json["draggedEntity"] = this.draggedEntity.id;
+		}
+		return json;
+	}
 
-  update(data) {
-    // Don't show a GMs drag ruler to non GM players
-    if (data.draggedEntity && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
-      return;
+	update(data) {
+		// Don't show a GMs drag ruler to non GM players
+		if (data.draggedEntity && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
+			return;
 
-    if (data.draggedEntity) {
-      if (data.draggedEntityIsToken)
-        this.draggedEntity = canvas.tokens.get(data.draggedEntity);
-      else
-        this.draggedEntity = canvas.templates.get(data.draggedEntity);
-    }
+		if (data.draggedEntity) {
+			if (data.draggedEntityIsToken)
+				this.draggedEntity = canvas.tokens.get(data.draggedEntity);
+			else
+				this.draggedEntity = canvas.templates.get(data.draggedEntity);
+		}
 
-    super.update(data);
-  }
+		super.update(data);
+	}
 
-  measure(destination, options={}) {
-    if (this.isDragRuler) {
-      return measure.call(this, destination, options);
-    }
-    else {
-      return super.measure(destination, options);
-    }
-  }
+	measure(destination, options={}) {
+		if (this.isDragRuler) {
+			return measure.call(this, destination, options);
+		}
+		else {
+			return super.measure(destination, options);
+		}
+	}
 
-  _endMeasurement() {
-    super._endMeasurement();
-    this.draggedEntity = null;
-  }
+	_endMeasurement() {
+		super._endMeasurement();
+		this.draggedEntity = null;
+	}
 
-  // The functions below aren't present in the orignal Ruler class and are added by Drag Ruler
-  dragRulerAddWaypoint(point, options={}) {
-          console.log(`drag-ruler|Adding waypoint ${point.x}, ${point.y}`);
-    options.snap = options.snap ?? true;
-    if (options.snap) {
-      point = getSnapPointForEntity(point.x, point.y, this.draggedEntity);
-    }
-    this.waypoints.push(new PIXI.Point(point.x, point.y));
-    this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
-  }
+	// The functions below aren't present in the orignal Ruler class and are added by Drag Ruler
+	dragRulerAddWaypoint(point, options={}) {
+					console.log(`drag-ruler|Adding waypoint ${point.x}, ${point.y}`);
+		options.snap = options.snap ?? true;
+		if (options.snap) {
+			point = getSnapPointForEntity(point.x, point.y, this.draggedEntity);
+		}
+		this.waypoints.push(new PIXI.Point(point.x, point.y));
+		this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
+	}
 }
 
 // export for use in libruler code as well as here.
 export function dragRulerAddWaypointHistory(waypoints) {
-    waypoints.forEach(waypoint => waypoint.isPrevious = true);
-    this.waypoints = this.waypoints.concat(waypoints);
-    for (const waypoint of waypoints) {
-      this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
-    }
-  }
+		waypoints.forEach(waypoint => waypoint.isPrevious = true);
+		this.waypoints = this.waypoints.concat(waypoints);
+		for (const waypoint of waypoints) {
+			this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
+		}
+	}
 
 export function dragRulerClearWaypoints() {
-    this.waypoints = [];
-    this.labels.removeChildren().forEach(c => c.destroy());
-  }
+		this.waypoints = [];
+		this.labels.removeChildren().forEach(c => c.destroy());
+	}
 
 export function dragRulerDeleteWaypoint(event={preventDefault: () => {return}}, options={}) {
-    options.snap = options.snap ?? true;
-    if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
-      event.preventDefault();
-      const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
-      const rulerOffset = game.modules.get('libruler')?.active ? this.getFlag(settingsKey, "rulerOffset") : this.rulerOffset;
+		options.snap = options.snap ?? true;
+		if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
+			event.preventDefault();
+			const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
+			const rulerOffset = game.modules.get('libruler')?.active ? this.getFlag(settingsKey, "rulerOffset") : this.rulerOffset;
 
-      // Options are not passed to _removeWaypoint in vanilla Foundry.
-      // Send them in case other modules have overriden that behavior and accept an options parameter (Toggle Snap to Grid)
-      this._removeWaypoint({x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y}, options);
-      game.user.broadcastActivity({ruler: this});
-    }
-    else {
-      this.dragRulerAbortDrag(event);
-    }
-  }
+			// Options are not passed to _removeWaypoint in vanilla Foundry.
+			// Send them in case other modules have overriden that behavior and accept an options parameter (Toggle Snap to Grid)
+			this._removeWaypoint({x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y}, options);
+			game.user.broadcastActivity({ruler: this});
+		}
+		else {
+			this.dragRulerAbortDrag(event);
+		}
+	}
 
 export function dragRulerAbortDrag(event={preventDefault: () => {return}}) {
-    const token = this.draggedEntity;
-    this._endMeasurement();
+		const token = this.draggedEntity;
+		this._endMeasurement();
 
-    // Deactivate the drag workflow in mouse
-    token.mouseInteractionManager._deactivateDragEvents();
-    token.mouseInteractionManager.state = token.mouseInteractionManager.states.HOVER;
+		// Deactivate the drag workflow in mouse
+		token.mouseInteractionManager._deactivateDragEvents();
+		token.mouseInteractionManager.state = token.mouseInteractionManager.states.HOVER;
 
-    // This will cancel the current drag operation
-    // Pass in a fake event that hopefully is enough to allow other modules to function
-    token._onDragLeftCancel(event);
-  }
+		// This will cancel the current drag operation
+		// Pass in a fake event that hopefully is enough to allow other modules to function
+		token._onDragLeftCancel(event);
+	}
 
 export async function dragRulerRecalculate(tokenIds) {
-    if (this._state !== Ruler.STATES.MEASURING)
-      return;
-    if (tokenIds && !tokenIds.includes(this.draggedEntity.id))
-      return;
-    const waypoints = this.waypoints.filter(waypoint => !waypoint.isPrevious);
-    this.dragRulerClearWaypoints();
-    if (game.settings.get(settingsKey, "enableMovementHistory"))
-      this.dragRulerAddWaypointHistory(getMovementHistory(this.draggedEntity));
-    for (const waypoint of waypoints) {
-      if(game.modules.get('libruler')?.active) {
-        this._addWaypoint(waypoint, false);
-      } else {
-        this.dragRulerAddWaypoint(waypoint, {snap: false});
-      }
-    }
-    this.measure(this.destination);
-    game.user.broadcastActivity({ruler: this});
-  }
+		if (this._state !== Ruler.STATES.MEASURING)
+			return;
+		if (tokenIds && !tokenIds.includes(this.draggedEntity.id))
+			return;
+		const waypoints = this.waypoints.filter(waypoint => !waypoint.isPrevious);
+		this.dragRulerClearWaypoints();
+		if (game.settings.get(settingsKey, "enableMovementHistory"))
+			this.dragRulerAddWaypointHistory(getMovementHistory(this.draggedEntity));
+		for (const waypoint of waypoints) {
+			if(game.modules.get('libruler')?.active) {
+				this._addWaypoint(waypoint, false);
+			} else {
+				this.dragRulerAddWaypoint(waypoint, {snap: false});
+			}
+		}
+		this.measure(this.destination);
+		game.user.broadcastActivity({ruler: this});
+	}
 
 export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
-    if ( destination )
-      waypoints = waypoints.concat([destination]);
-    return waypoints.slice(1).map((wp, i) => {
-      const ray =  new Ray(waypoints[i], wp);
-      ray.isPrevious = Boolean(waypoints[i].isPrevious);
-      return ray;
-    });
-  }
+		if ( destination )
+			waypoints = waypoints.concat([destination]);
+		return waypoints.slice(1).map((wp, i) => {
+			const ray =	 new Ray(waypoints[i], wp);
+			ray.isPrevious = Boolean(waypoints[i].isPrevious);
+			return ray;
+		});
+	}
 
 	dragRulerGetColorForDistance(distance) {
 		if (!this.isDragRuler)
@@ -184,37 +184,37 @@ export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
 
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerAddWaypointHistory", {
-  value: dragRulerAddWaypointHistory,
-  writable: true,
-  configurable: true
+	value: dragRulerAddWaypointHistory,
+	writable: true,
+	configurable: true
 });
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerClearWaypoints", {
-  value: dragRulerClearWaypoints,
-  writable: true,
-  configurable: true
+	value: dragRulerClearWaypoints,
+	writable: true,
+	configurable: true
 });
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerDeleteWaypoint", {
-  value: dragRulerDeleteWaypoint,
-  writable: true,
-  configurable: true
+	value: dragRulerDeleteWaypoint,
+	writable: true,
+	configurable: true
 });
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerAbortDrag", {
-  value: dragRulerAbortDrag,
-  writable: true,
-  configurable: true
+	value: dragRulerAbortDrag,
+	writable: true,
+	configurable: true
 });
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerRecalculate", {
-  value: dragRulerRecalculate,
-  writable: true,
-  configurable: true
+	value: dragRulerRecalculate,
+	writable: true,
+	configurable: true
 });
 
 Object.defineProperty(DragRulerRuler, "dragRulerGetRaysFromWaypoints", {
-  value: dragRulerGetRaysFromWaypoints,
-  writable: true,
-  configurable: true
+	value: dragRulerGetRaysFromWaypoints,
+	writable: true,
+	configurable: true
 });

--- a/src/ruler.js
+++ b/src/ruler.js
@@ -86,8 +86,10 @@ export class DragRulerRuler extends Ruler {
 		this.waypoints.push(new PIXI.Point(point.x, point.y));
 		this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
 	}
+}
 
-	dragRulerAddWaypointHistory(waypoints) {
+// export for use in libruler code as well as here.
+export function dragRulerAddWaypointHistory(waypoints) {
 		waypoints.forEach(waypoint => waypoint.isPrevious = true);
 		this.waypoints = this.waypoints.concat(waypoints);
 		for (const waypoint of waypoints) {
@@ -95,17 +97,17 @@ export class DragRulerRuler extends Ruler {
 		}
 	}
 
-	dragRulerClearWaypoints() {
+export function	dragRulerClearWaypoints() {
 		this.waypoints = [];
 		this.labels.removeChildren().forEach(c => c.destroy());
 	}
 
-	dragRulerDeleteWaypoint(event={preventDefault: () => {return}}, options={}) {
+export function	dragRulerDeleteWaypoint(event={preventDefault: () => {return}}, options={}) {
 		options.snap = options.snap ?? true;
 		if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
 			event.preventDefault();
 			const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
-			const rulerOffset = this.rulerOffset;
+			const rulerOffset = game.modules.get('libruler')?.active ? this.getFlag(settingsKey, "rulerOffset") : this.rulerOffset;
 
 			// Options are not passed to _removeWaypoint in vanilla Foundry.
 			// Send them in case other modules have overriden that behavior and accept an options parameter (Toggle Snap to Grid)
@@ -117,7 +119,7 @@ export class DragRulerRuler extends Ruler {
 		}
 	}
 
-	dragRulerAbortDrag(event={preventDefault: () => {return}}) {
+export function dragRulerAbortDrag(event={preventDefault: () => {return}}) {
 		const token = this.draggedEntity;
 		this._endMeasurement();
 
@@ -130,7 +132,7 @@ export class DragRulerRuler extends Ruler {
 		token._onDragLeftCancel(event);
 	}
 
-	async dragRulerRecalculate(tokenIds) {
+export async dragRulerRecalculate(tokenIds) {
 		if (this._state !== Ruler.STATES.MEASURING)
 			return;
 		if (tokenIds && !tokenIds.includes(this.draggedEntity.id))
@@ -140,13 +142,17 @@ export class DragRulerRuler extends Ruler {
 		if (game.settings.get(settingsKey, "enableMovementHistory"))
 			this.dragRulerAddWaypointHistory(getMovementHistory(this.draggedEntity));
 		for (const waypoint of waypoints) {
-			this.dragRulerAddWaypoint(waypoint, {snap: false});
+		  if(game.modules.get('libruler')?.active) {
+		    this._addWaypoint(waypoint, false);
+		  } else {
+		    this.dragRulerAddWaypoint(waypoint, {snap: false});
+		  }
 		}
 		this.measure(this.destination);
 		game.user.broadcastActivity({ruler: this});
 	}
 
-	static dragRulerGetRaysFromWaypoints(waypoints, destination) {
+export dragRulerGetRaysFromWaypoints(waypoints, destination) {
 		if ( destination )
 			waypoints = waypoints.concat([destination]);
 		return waypoints.slice(1).map((wp, i) => {
@@ -174,3 +180,40 @@ export class DragRulerRuler extends Ruler {
 		return getColorForDistanceAndToken(distance, this.draggedEntity, this.dragRulerRanges);
 	}
 }
+
+
+Object.defineProperty(DragRulerRuler.prototype, "dragRulerAddWaypointHistory", {
+  value: dragRulerAddWaypointHistory,
+	writable: true,
+	configurable: true
+});
+
+Object.defineProperty(DragRulerRuler.prototype, "dragRulerClearWaypoints", {
+  value: dragRulerClearWaypoints,
+	writable: true,
+	configurable: true
+});
+
+Object.defineProperty(DragRulerRuler.prototype, "dragRulerDeleteWaypoint", {
+  value: dragRulerDeleteWaypoint,
+	writable: true,
+	configurable: true
+});
+
+Object.defineProperty(DragRulerRuler.prototype, "dragRulerAbortDrag", {
+  value: dragRulerAbortDrag,
+	writable: true,
+	configurable: true
+});
+
+Object.defineProperty(DragRulerRuler.prototype, "dragRulerRecalculate", {
+  value: dragRulerRecalculate,
+	writable: true,
+	configurable: true
+});
+
+Object.defineProperty(DragRulerRuler, "dragRulerGetRaysFromWaypoints", {
+  value: dragRulerGetRaysFromWaypoints,
+	writable: true,
+	configurable: true
+});

--- a/src/ruler.js
+++ b/src/ruler.js
@@ -77,6 +77,7 @@ export class DragRulerRuler extends Ruler {
 
 	// The functions below aren't present in the orignal Ruler class and are added by Drag Ruler
 	dragRulerAddWaypoint(point, options={}) {
+          console.log(`drag-ruler|Adding waypoint ${point.x}, ${point.y}`);
 		options.snap = options.snap ?? true;
 		if (options.snap) {
 			point = getSnapPointForEntity(point.x, point.y, this.draggedEntity);

--- a/src/ruler.js
+++ b/src/ruler.js
@@ -132,7 +132,7 @@ export function dragRulerAbortDrag(event={preventDefault: () => {return}}) {
 		token._onDragLeftCancel(event);
 	}
 
-export async dragRulerRecalculate(tokenIds) {
+export async function dragRulerRecalculate(tokenIds) {
 		if (this._state !== Ruler.STATES.MEASURING)
 			return;
 		if (tokenIds && !tokenIds.includes(this.draggedEntity.id))
@@ -152,7 +152,7 @@ export async dragRulerRecalculate(tokenIds) {
 		game.user.broadcastActivity({ruler: this});
 	}
 
-export dragRulerGetRaysFromWaypoints(waypoints, destination) {
+export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
 		if ( destination )
 			waypoints = waypoints.concat([destination]);
 		return waypoints.slice(1).map((wp, i) => {
@@ -180,6 +180,7 @@ export dragRulerGetRaysFromWaypoints(waypoints, destination) {
 		return getColorForDistanceAndToken(distance, this.draggedEntity, this.dragRulerRanges);
 	}
 }
+
 
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerAddWaypointHistory", {

--- a/src/ruler.js
+++ b/src/ruler.js
@@ -5,162 +5,162 @@ import {settingsKey} from "./settings.js";
 import {getSnapPointForEntity, setSnapParameterOnOptions} from "./util.js";
 
 export class DragRulerRuler extends Ruler {
-	// Functions below are overridden versions of functions in Ruler
-	constructor(user, {color=null}={}) {
-		super(user, {color});
-		this.previousWaypoints = [];
-		this.previousLabels = this.addChild(new PIXI.Container());
-	}
+  // Functions below are overridden versions of functions in Ruler
+  constructor(user, {color=null}={}) {
+    super(user, {color});
+    this.previousWaypoints = [];
+    this.previousLabels = this.addChild(new PIXI.Container());
+  }
 
-	clear() {
-		super.clear();
-		this.previousWaypoints = [];
-		this.previousLabels.removeChildren().forEach(c => c.destroy());
-		this.dragRulerRanges = undefined;
-		cancelScheduledMeasurement.call(this);
-	}
+  clear() {
+    super.clear();
+    this.previousWaypoints = [];
+    this.previousLabels.removeChildren().forEach(c => c.destroy());
+    this.dragRulerRanges = undefined;
+    cancelScheduledMeasurement.call(this);
+  }
 
-	async moveToken(event) {
+  async moveToken(event) {
           console.log(`drag-ruler|moveToken`, this);
-		// This function is invoked by left clicking
-		if (!this.isDragRuler)
-			return await super.moveToken(event);
+    // This function is invoked by left clicking
+    if (!this.isDragRuler)
+      return await super.moveToken(event);
 
-		let options = {};
-		setSnapParameterOnOptions(this, options);
+    let options = {};
+    setSnapParameterOnOptions(this, options);
 
-		if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
-			this.dragRulerAddWaypoint(this.destination, options);
-		}
-		else {
-			this.dragRulerDeleteWaypoint(event, options);
-		}
-	}
+    if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
+      this.dragRulerAddWaypoint(this.destination, options);
+    }
+    else {
+      this.dragRulerDeleteWaypoint(event, options);
+    }
+  }
 
-	toJSON() {
-		const json = super.toJSON();
-		if (this.draggedEntity) {
-			const isToken = this.draggedEntity instanceof Token;
-			json["draggedEntityIsToken"] = isToken;
-			json["draggedEntity"] = this.draggedEntity.id;
-		}
-		return json;
-	}
+  toJSON() {
+    const json = super.toJSON();
+    if (this.draggedEntity) {
+      const isToken = this.draggedEntity instanceof Token;
+      json["draggedEntityIsToken"] = isToken;
+      json["draggedEntity"] = this.draggedEntity.id;
+    }
+    return json;
+  }
 
-	update(data) {
-		// Don't show a GMs drag ruler to non GM players
-		if (data.draggedEntity && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
-			return;
+  update(data) {
+    // Don't show a GMs drag ruler to non GM players
+    if (data.draggedEntity && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
+      return;
 
-		if (data.draggedEntity) {
-			if (data.draggedEntityIsToken)
-				this.draggedEntity = canvas.tokens.get(data.draggedEntity);
-			else
-				this.draggedEntity = canvas.templates.get(data.draggedEntity);
-		}
+    if (data.draggedEntity) {
+      if (data.draggedEntityIsToken)
+        this.draggedEntity = canvas.tokens.get(data.draggedEntity);
+      else
+        this.draggedEntity = canvas.templates.get(data.draggedEntity);
+    }
 
-		super.update(data);
-	}
+    super.update(data);
+  }
 
-	measure(destination, options={}) {
-		if (this.isDragRuler) {
-			return measure.call(this, destination, options);
-		}
-		else {
-			return super.measure(destination, options);
-		}
-	}
+  measure(destination, options={}) {
+    if (this.isDragRuler) {
+      return measure.call(this, destination, options);
+    }
+    else {
+      return super.measure(destination, options);
+    }
+  }
 
-	_endMeasurement() {
-		super._endMeasurement();
-		this.draggedEntity = null;
-	}
+  _endMeasurement() {
+    super._endMeasurement();
+    this.draggedEntity = null;
+  }
 
-	// The functions below aren't present in the orignal Ruler class and are added by Drag Ruler
-	dragRulerAddWaypoint(point, options={}) {
+  // The functions below aren't present in the orignal Ruler class and are added by Drag Ruler
+  dragRulerAddWaypoint(point, options={}) {
           console.log(`drag-ruler|Adding waypoint ${point.x}, ${point.y}`);
-		options.snap = options.snap ?? true;
-		if (options.snap) {
-			point = getSnapPointForEntity(point.x, point.y, this.draggedEntity);
-		}
-		this.waypoints.push(new PIXI.Point(point.x, point.y));
-		this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
-	}
+    options.snap = options.snap ?? true;
+    if (options.snap) {
+      point = getSnapPointForEntity(point.x, point.y, this.draggedEntity);
+    }
+    this.waypoints.push(new PIXI.Point(point.x, point.y));
+    this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
+  }
 }
 
 // export for use in libruler code as well as here.
 export function dragRulerAddWaypointHistory(waypoints) {
-		waypoints.forEach(waypoint => waypoint.isPrevious = true);
-		this.waypoints = this.waypoints.concat(waypoints);
-		for (const waypoint of waypoints) {
-			this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
-		}
-	}
+    waypoints.forEach(waypoint => waypoint.isPrevious = true);
+    this.waypoints = this.waypoints.concat(waypoints);
+    for (const waypoint of waypoints) {
+      this.labels.addChild(new PreciseText("", CONFIG.canvasTextStyle));
+    }
+  }
 
-export function	dragRulerClearWaypoints() {
-		this.waypoints = [];
-		this.labels.removeChildren().forEach(c => c.destroy());
-	}
+export function dragRulerClearWaypoints() {
+    this.waypoints = [];
+    this.labels.removeChildren().forEach(c => c.destroy());
+  }
 
-export function	dragRulerDeleteWaypoint(event={preventDefault: () => {return}}, options={}) {
-		options.snap = options.snap ?? true;
-		if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
-			event.preventDefault();
-			const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
-			const rulerOffset = game.modules.get('libruler')?.active ? this.getFlag(settingsKey, "rulerOffset") : this.rulerOffset;
+export function dragRulerDeleteWaypoint(event={preventDefault: () => {return}}, options={}) {
+    options.snap = options.snap ?? true;
+    if (this.waypoints.filter(w => !w.isPrevious).length > 1) {
+      event.preventDefault();
+      const mousePosition = canvas.app.renderer.plugins.interaction.mouse.getLocalPosition(canvas.tokens);
+      const rulerOffset = game.modules.get('libruler')?.active ? this.getFlag(settingsKey, "rulerOffset") : this.rulerOffset;
 
-			// Options are not passed to _removeWaypoint in vanilla Foundry.
-			// Send them in case other modules have overriden that behavior and accept an options parameter (Toggle Snap to Grid)
-			this._removeWaypoint({x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y}, options);
-			game.user.broadcastActivity({ruler: this});
-		}
-		else {
-			this.dragRulerAbortDrag(event);
-		}
-	}
+      // Options are not passed to _removeWaypoint in vanilla Foundry.
+      // Send them in case other modules have overriden that behavior and accept an options parameter (Toggle Snap to Grid)
+      this._removeWaypoint({x: mousePosition.x + rulerOffset.x, y: mousePosition.y + rulerOffset.y}, options);
+      game.user.broadcastActivity({ruler: this});
+    }
+    else {
+      this.dragRulerAbortDrag(event);
+    }
+  }
 
 export function dragRulerAbortDrag(event={preventDefault: () => {return}}) {
-		const token = this.draggedEntity;
-		this._endMeasurement();
+    const token = this.draggedEntity;
+    this._endMeasurement();
 
-		// Deactivate the drag workflow in mouse
-		token.mouseInteractionManager._deactivateDragEvents();
-		token.mouseInteractionManager.state = token.mouseInteractionManager.states.HOVER;
+    // Deactivate the drag workflow in mouse
+    token.mouseInteractionManager._deactivateDragEvents();
+    token.mouseInteractionManager.state = token.mouseInteractionManager.states.HOVER;
 
-		// This will cancel the current drag operation
-		// Pass in a fake event that hopefully is enough to allow other modules to function
-		token._onDragLeftCancel(event);
-	}
+    // This will cancel the current drag operation
+    // Pass in a fake event that hopefully is enough to allow other modules to function
+    token._onDragLeftCancel(event);
+  }
 
 export async function dragRulerRecalculate(tokenIds) {
-		if (this._state !== Ruler.STATES.MEASURING)
-			return;
-		if (tokenIds && !tokenIds.includes(this.draggedEntity.id))
-			return;
-		const waypoints = this.waypoints.filter(waypoint => !waypoint.isPrevious);
-		this.dragRulerClearWaypoints();
-		if (game.settings.get(settingsKey, "enableMovementHistory"))
-			this.dragRulerAddWaypointHistory(getMovementHistory(this.draggedEntity));
-		for (const waypoint of waypoints) {
-		  if(game.modules.get('libruler')?.active) {
-		    this._addWaypoint(waypoint, false);
-		  } else {
-		    this.dragRulerAddWaypoint(waypoint, {snap: false});
-		  }
-		}
-		this.measure(this.destination);
-		game.user.broadcastActivity({ruler: this});
-	}
+    if (this._state !== Ruler.STATES.MEASURING)
+      return;
+    if (tokenIds && !tokenIds.includes(this.draggedEntity.id))
+      return;
+    const waypoints = this.waypoints.filter(waypoint => !waypoint.isPrevious);
+    this.dragRulerClearWaypoints();
+    if (game.settings.get(settingsKey, "enableMovementHistory"))
+      this.dragRulerAddWaypointHistory(getMovementHistory(this.draggedEntity));
+    for (const waypoint of waypoints) {
+      if(game.modules.get('libruler')?.active) {
+        this._addWaypoint(waypoint, false);
+      } else {
+        this.dragRulerAddWaypoint(waypoint, {snap: false});
+      }
+    }
+    this.measure(this.destination);
+    game.user.broadcastActivity({ruler: this});
+  }
 
 export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
-		if ( destination )
-			waypoints = waypoints.concat([destination]);
-		return waypoints.slice(1).map((wp, i) => {
-			const ray =  new Ray(waypoints[i], wp);
-			ray.isPrevious = Boolean(waypoints[i].isPrevious);
-			return ray;
-		});
-	}
+    if ( destination )
+      waypoints = waypoints.concat([destination]);
+    return waypoints.slice(1).map((wp, i) => {
+      const ray =  new Ray(waypoints[i], wp);
+      ray.isPrevious = Boolean(waypoints[i].isPrevious);
+      return ray;
+    });
+  }
 
 	dragRulerGetColorForDistance(distance) {
 		if (!this.isDragRuler)
@@ -185,36 +185,36 @@ export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerAddWaypointHistory", {
   value: dragRulerAddWaypointHistory,
-	writable: true,
-	configurable: true
+  writable: true,
+  configurable: true
 });
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerClearWaypoints", {
   value: dragRulerClearWaypoints,
-	writable: true,
-	configurable: true
+  writable: true,
+  configurable: true
 });
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerDeleteWaypoint", {
   value: dragRulerDeleteWaypoint,
-	writable: true,
-	configurable: true
+  writable: true,
+  configurable: true
 });
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerAbortDrag", {
   value: dragRulerAbortDrag,
-	writable: true,
-	configurable: true
+  writable: true,
+  configurable: true
 });
 
 Object.defineProperty(DragRulerRuler.prototype, "dragRulerRecalculate", {
   value: dragRulerRecalculate,
-	writable: true,
-	configurable: true
+  writable: true,
+  configurable: true
 });
 
 Object.defineProperty(DragRulerRuler, "dragRulerGetRaysFromWaypoints", {
   value: dragRulerGetRaysFromWaypoints,
-	writable: true,
-	configurable: true
+  writable: true,
+  configurable: true
 });

--- a/src/socket.js
+++ b/src/socket.js
@@ -3,9 +3,11 @@ import {currentSpeedProvider} from "./api.js";
 let socket;
 
 Hooks.once("socketlib.ready", () => {
-	socket = socketlib.registerModule("drag-ruler");
-	socket.register("updateCombatantDragRulerFlags", _socketUpdateCombatantDragRulerFlags);
-	socket.register("recalculate", _socketRecalculate);
+  if(!game.modules.get('libruler')?.active) {
+		socket = socketlib.registerModule("drag-ruler");
+		socket.register("updateCombatantDragRulerFlags", _socketUpdateCombatantDragRulerFlags);
+		socket.register("recalculate", _socketRecalculate);
+	}
 });
 
 export function updateCombatantDragRulerFlags(combat, updates) {


### PR DESCRIPTION
Hi! This pull request offers basic compatibility with libRuler and related modules as a completely optional addition. The intention here is that if libRuler is installed, Drag Ruler will use that. If libRuler is not installed, it falls back on the existing Drag Ruler code.

This builds on the other, simpler, pull request I did for lib wrapper compatibility. So I will focus here on other modifications

I added a libruler.js file that contains most of the code. Where possible, it imports functions from the ruler.js file. Specifically:
- dragRulerAddWaypointHistory
- dragRulerClearWaypoints
- dragRulerDeleteWaypoint
- dragRulerAbortDrag
- dragRulerRecalculate

In order to accomplish this, I had to slightly modify ruler.js. I took those functions out of the DragRulerRuler class method definitions and make them their own functions that can be exported. Then I used `Object.defineProperty` to link each function to DragRulerRuler class (when not using libRuler) and the Ruler class (when using libRuler). I did not modify any of the functionality or code in ruler.js beyond that.

Edits to main.js are similarly intended to just be for libRuler. Basically just a bunch of switches to use libRuler if available but otherwise no modifications to the underlying code.

To check out how this works with libRuler, I recommend trying Drag Ruler along with
- [Elevation Ruler](https://github.com/caewok/fvtt-elevation-ruler)
- [Speed Ruler](https://github.com/caewok/fvtt-speed-ruler) (not yet released in Foundry)

I did not (yet) attempt:
1. Multiple selected tokens.
2. Colors. Speed Ruler can handle displaying different ruler colors for movement speed.
3. Movement History/Tracking. I expect this would be better moved to Speed Ruler, but probably worth a discussion about the bets approach.
4. API. Again, probably Speed Ruler for most of it. The underlying API is still there of course. 

Edit: Recent addition after testing---I wrapped the libRuler testForCollision method to return false whenever the GM is dragging a token. This allows GMs to drag tokens through walls, as expected. 