### PR TITLE
Add Lancer system integration info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Drag Ruler will work with all Foundry VTT game systems. However some game system
 The game systems that offer Drag Ruler integration are:
 - Cypher System (starting with version 1.13.0)
 - Ironclaw Second Edition (starting with version 0.2.2)
+- Lancer (via the module [Lancer Speed Provider](https://foundryvtt.com/packages/lancer-speed-provider))
 - Pathfinder 1 (starting with version 0.77.3)
 - Pathfinder 2e (via the module [PF2E Drag Ruler Integration](https://foundryvtt.com/packages/pf2e-dragruler/))
 - Tagmar RPG (starting with version 1.1.4)


### PR DESCRIPTION
Adds a link to the lancer-speed-provider module to the systems with integrations section.