### PR TITLE
Updated getFlag behaviour

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -11,7 +11,7 @@ export function getSnapPointForToken(x, y, token) {
 		return new PIXI.Point(x, y);
 	}
 	if (canvas.grid.isHex && game.modules.get("hex-size-support")?.active && CONFIG.hexSizeSupport.getAltSnappingFlag(token)) {
-		if (token.getFlag("hex-size-support", "borderSize") % 2 === 0) {
+		if (token.document.getFlag("hex-size-support", "borderSize") % 2 === 0) {
 			const snapPoint = CONFIG.hexSizeSupport.findVertexSnapPoint(x, y, token, canvas.grid.grid)
 			return new PIXI.Point(snapPoint.x, snapPoint.y)
 		}


### PR DESCRIPTION
Updated getFlag behaviour to use Document#getFlag rather than the depreciated PlaceableObject#getFlag. Due to the min core version being marked as 0.8.5, the issue of it being incompatible with Foundry 0.7 is not a concern here.