### PR TITLE
libRuler compatibility based on 1.9.0 branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Release Creation
 
-on: 
+on:
   release:
     types: [published]
 
@@ -28,7 +28,7 @@ jobs:
         download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
     # Create a zip file with all files required by the module to add to the release
-    - run: zip -r ./module.zip module.json LICENSE styles/ scripts/ templates/ languages/
+    - run: zip -r ./module.zip module.json LICENSE lang/ src/ templates/
 
     # Create a release for this specific version
     - name: Update Release with Files

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: Release Creation
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # get part of the tag after the `v`
+    - name: Extract tag version number
+      id: get_version
+      uses: battila7/get-version-action@v2
+
+    # Substitute the Manifest and Download URLs in the module.json
+    - name: Substitute Manifest and Download Links For Versioned Ones
+      id: sub_manifest_link_version
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: 'module.json'
+      env:
+        version: ${{steps.get_version.outputs.version-without-v}}
+        url: https://github.com/${{github.repository}}
+        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+        download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+
+    # Create a zip file with all files required by the module to add to the release
+    - run: zip -r ./module.zip module.json LICENSE styles/ scripts/ templates/ languages/
+
+    # Create a release for this specific version
+    - name: Update Release with Files
+      id: create_version_release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true # Set this to false if you want to prevent updating existing releases
+        name: ${{ github.event.release.name }}
+        draft: ${{ github.event.release.unpublished }}
+        prerelease: ${{ github.event.release.prerelease }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './module.json, ./module.zip'
+        tag: ${{ github.event.release.tag_name }}
+        body: ${{ github.event.release.body }}

--- a/src/foundry_imports.js
+++ b/src/foundry_imports.js
@@ -100,11 +100,11 @@ async function animateEntities(entities, draggedEntity, draggedRays, wasPaused) 
 		trackRays(entities, entityAnimationData.map(({rays}) => rays)).then(() => recalculate(entities));
 }
 
-function calculateEntityOffset(entityA, entityB) {
+export function calculateEntityOffset(entityA, entityB) {
 	return {x: entityA.data.x - entityB.data.x, y: entityA.data.y - entityB.data.y};
 }
 
-function applyOffsetToRay(ray, offset) {
+export function applyOffsetToRay(ray, offset) {
 	const newRay = new Ray({x: ray.A.x + offset.x, y: ray.A.y + offset.y}, {x: ray.B.x + offset.x, y: ray.B.y + offset.y});
 	newRay.isPrevious = ray.isPrevious;
 	return newRay;

--- a/src/libruler.js
+++ b/src/libruler.js
@@ -1,0 +1,360 @@
+import {settingsKey} from "./settings.js"
+import { applyTokenSizeOffset, getTokenShape, getSnapPointForToken, setSnapParameterOnOptions } from "./util.js";
+import { dragRulerAddWaypointHistory,
+				 dragRulerClearWaypoints,
+				 dragRulerDeleteWaypoint,
+				 dragRulerAbortDrag,
+				 dragRulerRecalculate } from "./ruler.js";
+
+import { cancelScheduledMeasurement, calculateEntityOffset, applyOffsetToRay } from "./foundry_imports.js";
+
+export function registerLibRuler() {
+	// Wrappers for base Ruler methods
+	libWrapper.register(settingsKey, "Ruler.prototype.clear", dragRulerClear, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype.update", dragRulerUpdate, "MIXED");
+	libWrapper.register(settingsKey, "Ruler.prototype._endMeasurement", dragRulerEndMeasurement, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype._onMouseMove", dragRulerOnMouseMove, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype._getMovementToken", dragRulerGetMovementToken, "MIXED");
+	libWrapper.register(settingsKey, "Ruler.prototype.moveToken", dragRulerMoveToken, "MIXED");
+
+	// Wrappers for libRuler Ruler methods
+	libWrapper.register(settingsKey, "Ruler.prototype.setDestination", dragRulerSetDestination, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype._addWaypoint", dragRulerAddWaypoint, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype.deferMeasurement", dragRulerDeferMeasurement, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype.cancelScheduledMeasurement", dragRulerCancelScheduledMeasurement, "WRAPPER");
+	libWrapper.register(settingsKey, "Ruler.prototype.doDeferredMeasurements", dragRulerDoDeferredMeasurements, "WRAPPER");
+  libWrapper.register(settingsKey, "Ruler.prototype.testForCollision", dragRulerTestForCollision, "MIXED");
+  libWrapper.register(settingsKey, "Ruler.prototype.animateToken", dragRulerAnimateToken, "WRAPPER");
+
+	// Wrappers for libRuler RulerSegment methods
+	libWrapper.register(settingsKey, "window.libRuler.RulerSegment.prototype.addProperties", dragRulerAddProperties, "WRAPPER");
+
+	addRulerProperties();
+
+	// tell libWrapper that it can ignore the conflict warning from drag ruler not always calling
+	// the underlying method for Ruler.moveToken. (i.e., drag ruler interrupts it
+	// if just adding or deleting a waypoint)
+	libWrapper.ignore_conflicts(settingsKey, "libruler", "Ruler.prototype.moveToken");
+}
+
+
+// Functions mostly adapted from ruler.js, originally in class DragRulerRuler
+
+/*
+ * Clear display of the current Ruler.
+ * Wrap for Ruler.clear
+ */
+function dragRulerClear(wrapped) {
+	this.cancelScheduledMeasurement();
+	wrapped();
+}
+
+
+/*
+ * Modify update to avoid showing a GM drag ruler to non-GM players.
+ * Wrap for Ruler.update
+ */
+function dragRulerUpdate(wrapped, data) {
+	if(this.draggedEntity && this.user.isGM && !game.user.isGM && !game.settings.get(settingsKey, "showGMRulerToPlayers"))
+			return;
+
+	wrapped(data);
+}
+
+/*
+ * clean up after measuring
+ */
+function dragRulerEndMeasurement(wrapped) {
+	this.unsetFlag(settingsKey, "draggedEntityID");
+	this.unsetFlag(settingsKey, "rulerOffset");
+	wrapped();
+}
+
+
+
+// Wrappers for libRuler Ruler methods
+
+/*
+ * Wrap for Ruler._onMouseMove
+ * Must set the offset for the destination before onMouseMove measures the distance
+ * Offset then used for the measurement, if it occurs
+ */
+
+function dragRulerOnMouseMove(wrapped, event) {
+	if(!this.isDragRuler) return wrapped(event);
+
+	const offset = this.getFlag(settingsKey, "rulerOffset");
+	event.data.destination.x = event.data.destination.x + offset.x;
+	event.data.destination.y = event.data.destination.y + offset.y;
+
+	wrapped(event);
+	// FYI: original drag ruler version calls this.measure with {snap: !originalEvent.shiftKey}, not {gridSpace: !originalEvent.shiftKey}
+}
+
+// The below deferMeasurement and cancelScheduleMeasurement handle situation in which
+// if a measurement is being skipped because of the ruler's rate limiting,
+// schedule the measurement for later to ensure the ruler sticks to the token
+// see https://github.com/manuelVo/foundryvtt-drag-ruler/commit/3cbe41e2be7b4ca8dabcf98094caad15a321ddc0#diff-8afd60da4c5dc44f5ed9d0c15918eab6724af29b5d385b05a1cd0aaa85bfcf8c
+
+/*
+ * Wrap for libRuler Ruler.deferMeasurement
+ *
+ */
+function dragRulerDeferMeasurement(wrapped, destination, event) {
+	if(this.isDragRuler) {
+		this.deferredMeasurementData = {destination, event};
+		if (!this.deferredMeasurementTimeout) {
+			this.deferredMeasurementPromise = new Promise((resolve, reject) => this.deferredMeasurementResolve = resolve);
+			this.deferredMeasurementTimeout = window.setTimeout(() => this.scheduleMeasurement(this.deferredMeasurementData.destination, this.deferredMeasurementData.event));
+		}
+	}
+	return wrapped(destination, event);
+}
+
+/*
+ * Wrap for libRuler Ruler.cancelScheduledMeasurement
+ * Uses existing internal drag ruler function to avoid unnecessary copy
+ */
+function dragRulerCancelScheduledMeasurement(wrapped) {
+	if(this.isDragRuler) { cancelScheduledMeasurement.call(this); }
+	return wrapped();
+}
+
+/*
+ * Wrap for libRuler Ruler.doDeferredMeasurement
+ * This is called from Ruler.moveToken and will catch the deferred promise in dragRulerDeferMeasurement above
+ */
+async function dragRulerDoDeferredMeasurements() {
+	if(this.isDragRuler) { await this.deferredMeasurementPromise; }
+	return wrapped();
+}
+
+/*
+ * Wrapper for libRuler Ruler.testForCollision
+ * Don't check for collisions if GM, so that GM can drag tokens through walls.
+ */
+function dragRulerTestForCollision(wrapped, rays) {
+ // taken from foundry_imports.js moveEntities function
+ if(this.isDragRuler) {
+   if(game.user.isGM) return false;
+   const draggedEntity = this._getMovementToken();
+
+   if(draggedEntity instanceof Token) {
+     const selectedEntities = canvas.tokens.controlled;
+     const hasCollision = selectedEntities.some(token => {
+			 const offset = calculateEntityOffset(token, draggedEntity);
+			 const offsetRays = rays.filter(ray => !ray.isPrevious).map(ray => applyOffsetToRay(ray, offset))
+			 return offsetRays.some(r => canvas.walls.checkCollision(r));
+		 });
+		 return hasCollision;
+   }
+ }
+
+ return wrapped(rays);
+}
+
+/*
+ * Modify destination to be the snap point for the token when snap is set.
+ * Wrap for Ruler.setDestination from libRuler.
+ * @param {Object} wrapped	Wrapped function from libWrapper.
+ * @param {Object} destination	The destination point to which to measure. Should have at least x and y properties.
+ */
+function dragRulerSetDestination(wrapped, destination) {
+	const snap = this.getFlag(settingsKey, "snap");
+	if(snap) {
+		const new_dest = getSnapPointForToken(destination.x, destination.y, this.draggedEntity);
+		destination.x = new_dest.x;
+		destination.y = new_dest.y;
+	}
+
+	wrapped(destination);
+}
+
+/*
+ * Wrapper for Ruler.moveToken
+ * Drag ruler original code breaks this out into two functions;
+ *	 - moveToken just adds or deletes waypoints; intercepting the space bar or right-click press
+ *	 - moveEntities is basically Ruler.moveToken with modifications
+ * To conform to libRuler and Foundry expectations, combine back into single wrap here
+ *	 - check a flag to start the actual movement
+ * TO-DO: Handle multiple entities
+ *				Handle measured template entity
+ */
+async function dragRulerMoveToken(wrapped) {
+	if(!this.isDragRuler || this._state === Ruler.STATES.MOVING) {
+		const p1 = wrapped();
+		const res = await p1;
+		return res;
+	}
+
+	let options = {};
+	setSnapParameterOnOptions(this, options);
+
+	if (!game.settings.get(settingsKey, "swapSpacebarRightClick")) {
+		this._addWaypoint(this.destination, options);
+	} else {
+		this.dragRulerDeleteWaypoint(event, options);
+	}
+
+	return undefined;
+}
+
+/*
+ * Wrapper for Ruler._addWaypoint
+ */
+function dragRulerAddWaypoint(wrapped, point, center = true) {
+	if(!this.isDragRuler) return wrapped(point, center);
+
+	if(center) {
+		point = getSnapPointForToken(point.x, point.y, this.draggedEntity);
+
+	}
+	return wrapped(point, false);
+}
+
+
+export function dragRulerGetRaysFromWaypoints(waypoints, destination) {
+		if ( destination )
+			waypoints = waypoints.concat([destination]);
+		return waypoints.slice(1).map((wp, i) => {
+			const ray =	 new Ray(waypoints[i], wp);
+			ray.isPrevious = Boolean(waypoints[i].isPrevious);
+			return ray;
+		});
+	}
+
+
+/*
+ * Wrap for Ruler._getMovementToken()
+ */
+
+// See drag ruler original version of moveTokens in foundry_imports.js
+function dragRulerGetMovementToken(wrapped) {
+	if(!this.isDragRuler) return wrapped();
+	return this.draggedEntity;
+}
+
+/*
+ * Wrap animate token to adjust ray for multiple tokens
+ */
+async function dragRulerAnimateToken(wrapped, token, ray, dx, dy, segment_num) {
+  let selectedEntities = canvas.tokens.controlled; // should include the dragged entity, right?
+  const isToken = token instanceof Token;
+  const animate = isToken && !game.keyboard.isDown("Alt");
+  selectedEntities = selectedEntities.filter(e => e.id !== token.id); // pull out the dragged token.
+
+  console.log(`drag-ruler|${animate ? "animating" : "not animating"} ${selectedEntities.length} selected tokens with dx, dy ${dx}, ${dy}`, token, selectedEntities)
+
+	// probably don't want to do the following b/c (1) need path from the wrapped function and (2) wrapped function already does the update
+	// await draggedEntity.scene.updateEmbeddedDocuments(draggedEntity.constructor.embeddedName, updates, {animate});
+
+  // animate the selected additional tokens using promises so they move as a group.
+  const promises = [];
+  for(const entity of selectedEntities) {
+    //const top_left = canvas.grid.getTopLeft(entity.center.x, entity.center.y);
+    const offset = { x: entity.center.x - token.center.x, y: entity.center.y - token.center.y };
+    const offsetRay = new Ray(ray.A, { x: ray.B.x + offset.x, y: ray.B.y + offset.y });
+    console.log(`drag-ruler|Animating entity ${entity.name} from ${entity.center.x}, ${entity.center.y} to ${offsetRay.B.x}, ${offsetRay.B.y}. Token ${token.name} at ${token.center.x}, ${token.center.y}. Offset ${offset.x}, ${offset.y}`);
+
+    // don't await here b/c this makes the tokens all move one-by-one
+    promises.push(wrapped(entity, offsetRay, dx, dy, segment_num)); // usually works, but can occassionally fail to keep multiple tokens in original arrangement
+    //promises.push(wrapped(entity, ray, dx + offset.x, dy + offset.y, segment_num)); // Fails to keep tokens in original arrangement much of the time
+  }
+
+  // use Promise.all to await to avoid confusing move errors if moving repeatedly very quickly
+  console.log(`drag-ruler|Animating ${token.name} from ${token.center.x}, ${token.center.y} to ${ray.B.x}, ${ray.B.y}`);
+  promises.push(wrapped(token, ray, dx, dy, segment_num));
+  const res = await Promise.allSettled(promises);
+
+  // need to return the path from the movement for the token
+  console.log("drag-ruler|AnimateToken returns", res);
+  return res[res.length -1].value;  // Promise.allSettled returns an array of [{status: , value: }]; Promise.all returns an array
+}
+
+// Wrappers for libRuler RulerSegment methods
+function dragRulerAddProperties(wrapped) {
+	wrapped();
+	if(!this.ruler.isDragRuler) return;
+
+	// center the segments
+	// TO-DO: Can Terrain Ruler handle its part separately? So just center everything here?
+	// See if (!terrainRulerAvailable) in drag ruler original measure function
+	const centeredWaypoints = applyTokenSizeOffset([this.ray.A, this.ray.B], this.ruler.draggedEntity);
+	centeredWaypoints.forEach(w => [w.x, w.y] = canvas.grid.getCenter(w.x, w.y));
+
+	this.ray = new Ray(centeredWaypoints[0], centeredWaypoints[1]);
+
+	// can pull origin information from the original waypoints
+	// segment 0 would have origin waypoint 0, destination waypoint 1, etc.
+	const origin = this.ruler.waypoints[this.segment_num];
+	this.ray.isPrevious = Boolean(origin.isPrevious);
+	this.ray.dragRulerVisitedSpaces = origin.dragRulerVisitedSpaces;
+	this.ray.dragRulerFinalState = origin.dragRulerFinalState;
+
+	// set opacity for drawing the line and the highlight
+	const opacity_mult = this.ray.isPrevious ? 0.33 : 1;
+	this.opacityMultipliers.line = opacity_mult;
+	this.opacityMultipliers.highlight = opacity_mult;
+}
+
+// Additions to Ruler class
+function addRulerProperties() {
+	// Add a getter method to check for drag token in Ruler flags.
+	Object.defineProperty(Ruler.prototype, "isDragRuler", {
+		get() { return Boolean(this.getFlag(settingsKey, "draggedEntityID")); },
+		configurable: true
+	});
+
+	// Add a getter method to return the token for the stored token id
+	Object.defineProperty(Ruler.prototype, "draggedEntity", {
+		get() {
+			const draggedEntityID = this.getFlag(settingsKey, "draggedEntityID");
+			if(!draggedEntityID) return undefined;
+			return canvas.tokens.get(draggedEntityID);
+		},
+		configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerAddWaypointHistory", {
+		value: dragRulerAddWaypointHistory,
+		writable: true,
+		configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerClearWaypoints", {
+		value: dragRulerClearWaypoints,
+		writable: true,
+		configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerDeleteWaypoint", {
+		value: dragRulerDeleteWaypoint,
+		writable: true,
+		configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerAbortDrag", {
+		value: dragRulerAbortDrag,
+		writable: true,
+		configurable: true
+	});
+
+	Object.defineProperty(Ruler.prototype, "dragRulerRecalculate", {
+		value: dragRulerRecalculate,
+		writable: true,
+		configurable: true
+	});
+
+	Object.defineProperty(Ruler, "dragRulerGetRaysFromWaypoints", {
+		value: dragRulerGetRaysFromWaypoints,
+		writable: true,
+		configurable: true
+	});
+}
+
+
+
+
+
+
+

--- a/src/libwrapper.js
+++ b/src/libwrapper.js
@@ -1,0 +1,66 @@
+// Hooks using libWrapper
+import { onEntityLeftDragStart,
+         onEntityLeftDragMove,
+         onEntityDragLeftDrop,
+         onEntityDragLeftCancel,
+         handleKeys } from "./main.js";
+
+import { removeLastHistoryEntryIfAt } from "./movement_tracking.js";
+import { settingsKey } from "./settings.js"
+
+
+export function registerLibWrapper() {
+  libWrapper.register(settingsKey, "Token.prototype._onDragLeftStart", onTokenLeftDragStartWrap, "WRAPPER");
+  libWrapper.register(settingsKey, "Token.prototype._onDragLeftMove", onDragLeftMoveWrap, "WRAPPER");
+  libWrapper.register(settingsKey, "Token.prototype._onDragLeftDrop", onDragLeftDropWrap, "MIXED");
+  libWrapper.register(settingsKey, "Token.prototype._onDragLeftCancel", onDragLeftCancelWrap, "MIXED");
+
+  libWrapper.register(settingsKey, "KeyboardManager.prototype._handleKeyboardEvent", handleKeysWrap, "MIXED");
+
+  libWrapper.register(settingsKey, "TokenLayer.prototype.undoHistory", dragRulerUndoHistory, "WRAPPER");
+}
+
+// simple wraps to keep the original functionality when not using libWrapper
+function onTokenLeftDragStartWrap(wrapped, event) {
+  wrapped(event);
+  onEntityLeftDragStart.call(this, event);
+}
+
+function onDragLeftMoveWrap(wrapped, event) {
+  wrapped(event);
+  onEntityLeftDragMove.call(this, event);
+}
+
+function onDragLeftDropWrap(wrapped, event) {
+  const eventHandled = onEntityDragLeftDrop.call(this, event);
+  if(!eventHandled) {
+    wrapped(event);
+  }
+}
+
+function onDragLeftCancelWrap(wrapped, event) {
+  const eventHandled = onEntityDragLeftCancel.call(this, event);
+  if(!eventHandled) {
+    wrapped(event);
+  }
+}
+
+function handleKeysWrap(wrapped, event, up) {
+  const eventHandled = handleKeys.call(this, event, up);
+  if(!eventHandled) {
+    wrapped(event, up);
+  }
+}
+
+async function dragRulerUndoHistory(wrapped) {
+  const historyEntry = this.history[this.history.length - 1];
+  const returnValue = await wrapped();
+
+  if (historyEntry.type === "update") {
+    for (const entry of historyEntry.data) {
+      const token = canvas.tokens.get(entry._id);
+      removeLastHistoryEntryIfAt(token, entry.x, entry.y);
+    }
+  }
+  return returnValue;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,22 @@
+/* globals
+Hooks,
+game,
+Token,
+MeasuredTemplate,
+Ruler:writable,
+canvas,
+KeyboardManager,
+TokenLayer,
+ui,
+CONFIG,
+terrainRuler,
+CONST
+*/
+
 "use strict"
 
 import {currentSpeedProvider, getColorForDistanceAndToken, getMovedDistanceFromToken, getRangesFromSpeedProvider, initApi, registerModule, registerSystem} from "./api.js";
-import {checkDependencies, getHexSizeSupportTokenGridCenter, highlightMeasurementTerrainRuler} from "./compatibility.js";
+import {checkDependencies, getHexSizeSupportTokenGridCenter} from "./compatibility.js";
 import {moveEntities, onMouseMove} from "./foundry_imports.js"
 import {performMigrations} from "./migration.js"
 import {DragRulerRuler} from "./ruler.js";
@@ -9,7 +24,7 @@ import {getMovementHistory, removeLastHistoryEntryIfAt, resetMovementHistory} fr
 import {registerSettings, settingsKey} from "./settings.js"
 import {recalculate} from "./socket.js";
 import {SpeedProvider} from "./speed_provider.js"
-import {isClose, setSnapParameterOnOptions} from "./util.js";
+import {setSnapParameterOnOptions} from "./util.js";
 import {registerLibWrapper} from "./libwrapper.js";
 import {registerLibRuler} from "./libruler.js";
 
@@ -26,9 +41,7 @@ Hooks.once("init", () => {
 		registerLibWrapper();
 	}
 
-
-
-	if(!game.modules.get('lib-wrapper')?.active) { Ruler = DragRulerRuler; }
+	if(!game.modules.get('libruler')?.active) { Ruler = DragRulerRuler; }
 
 	window.dragRuler = {
 		getColorForDistanceAndToken,
@@ -103,7 +116,7 @@ function hookDragHandlers(entityType) {
 }
 
 function hookKeyboardManagerFunctions() {
-	const originalHandleKeys = KeyboardManager.prototype._handleKeyboardEvent(event, up)
+	const originalHandleKeys = KeyboardManager.prototype._handleKeyboardEvent
 	KeyboardManager.prototype._handleKeyboardEvent = function (event, up) {
 		const eventHandled = handleKeys.call(this, event, up)
 		if (!eventHandled)

--- a/src/socket.js
+++ b/src/socket.js
@@ -3,9 +3,11 @@ import {currentSpeedProvider} from "./api.js";
 let socket;
 
 Hooks.once("socketlib.ready", () => {
-	socket = socketlib.registerModule("drag-ruler");
-	socket.register("updateCombatantDragRulerFlags", _socketUpdateCombatantDragRulerFlags);
-	socket.register("recalculate", _socketRecalculate);
+	if(!game.modules.get('libruler')?.active) {
+		socket = socketlib.registerModule("drag-ruler");
+		socket.register("updateCombatantDragRulerFlags", _socketUpdateCombatantDragRulerFlags);
+		socket.register("recalculate", _socketRecalculate);
+	}
 });
 
 export function updateCombatantDragRulerFlags(combat, updates) {


### PR DESCRIPTION
Hi! This pull request offers basic compatibility with libRuler and related modules as a completely optional addition. The intention here is that if libRuler is installed, Drag Ruler will use that. If libRuler is not installed, it falls back on the existing Drag Ruler code.

I added a libruler.js file that contains most of the code. Where possible, it imports functions from the ruler.js file. Specifically:

-     dragRulerAddWaypointHistory
-     dragRulerClearWaypoints
-     dragRulerDeleteWaypoint
-     dragRulerAbortDrag
-     dragRulerRecalculate

In order to accomplish this, I had to slightly modify ruler.js. I took those functions out of the DragRulerRuler class method definitions and make them their own functions that can be exported. Then I used Object.defineProperty to link each function to DragRulerRuler class (when not using libRuler) and the Ruler class (when using libRuler). I did not modify any of the functionality or code in ruler.js beyond that.

Edits to main.js are similarly intended to just be for libRuler. Basically just a bunch of switches to use libRuler if available but otherwise no modifications to the underlying code.

To check out how this works with libRuler, I recommend trying Drag Ruler along with
-     Elevation Ruler
-     Speed Ruler (not yet released in Foundry)
