### PR TITLE
dnd 4e system support

### DIFF
--- a/js/systems.js
+++ b/js/systems.js
@@ -4,13 +4,15 @@ export function getDefaultSpeedAttribute() {
 			return "actor.data.data.attribs.mov.value";
 		case "dcc":
 			return "actor.data.data.attributes.speed.value";
+		case "dnd4e":
+			return "actor.data.data.movement.walk.value";
 		case "dnd5e":
-			return "actor.data.data.attributes.movement.walk"
+			return "actor.data.data.attributes.movement.walk";
 		case "lancer":
-			return "actor.data.data.derived.speed"
+			return "actor.data.data.derived.speed";
 		case "pf1":
 		case "D35E":
-			return "actor.data.data.attributes.speed.land.total"
+			return "actor.data.data.attributes.speed.land.total";
 		case "sfrpg":
 			return "actor.data.data.attributes.speed.value";
 		case "shadowrun5e":
@@ -28,6 +30,7 @@ export function getDefaultDashMultiplier() {
 		case "swade":
 			return 0
 		case "dcc":
+		case "dnd4e":
 		case "dnd5e":
 		case "lancer":
 		case "pf1":
@@ -35,9 +38,9 @@ export function getDefaultDashMultiplier() {
 		case "sfrpg":
 		case "shadowrun5e":
 		case "ds4":
-			return 2
+			return 2;
 		case "CoC7":
 			return 5;
 	}
-	return 0
+	return 0;
 }


### PR DESCRIPTION
Adds system support for dnd4e movement based on standard walking speed as well as a having dash be set based on using two move actions. (aka double moving)
Also adds in some missing semicolons, obviously doesn't really matter but it was inconsistent.