### PR TITLE
Improve Pathfinding

### DIFF
--- a/js/queues.js
+++ b/js/queues.js
@@ -1,0 +1,125 @@
+/**
+ * Queue that will only ever accept a single value once
+ */
+export class ProcessOnceQueue {
+	constructor() {
+		this.first = null;
+		this.last = null;
+		this.queued = new Set();
+	}
+
+	push(value) {
+		if (this.queued.has(value)) {
+			return;
+		}
+		this.queued.add(value);
+
+		const newNode = {
+			value,
+			next: null,
+			previous: null
+		}
+
+		if (!this.first) {
+			this.first = newNode;
+			this.last = newNode;
+		} else {
+			this.last.next = newNode;
+			newNode.previous = this.last;
+			this.last = newNode;
+		}
+	}
+
+	pop() {
+		const node = this.first;
+		this.first = node?.next;
+		if (!node.next) {
+			this.last = null;
+		}
+		return node.value;
+	}
+
+	hasNext() {
+		return !!this.first;
+	}
+}
+
+/**
+ * Class to make an ordered queue where all the elements are unique, according to the equivalencyCheck.
+ * On insert, the element will only be added if there is not already a higher-priority equivalent element in the queue.
+ * If there is a lower-priority equivalent element in the queue, it will be removed.
+ */
+export class UniquePriorityQueue {
+	constructor(equivalencyCheck) {
+		this.first = null;
+		this.equivalencyCheck = equivalencyCheck;
+	}
+
+	push(value, priority) {
+		const newNode = { value, priority, next: null };
+
+		// If the queue is currently empty, we can just set this new node as the first and we're done
+		if (!this.first) {
+			this.first = newNode;
+			return;
+		}
+
+		let inserted = false;
+		let previous;
+		let current = this.first;
+
+		// Loop through the existing elements
+		while (current) {
+			if (this.equivalencyCheck(current.value, value)) {
+				// We've found an equivalent element before one with a lower priority. This one has at least
+				// the same priority as the new one, so don't bother inserting
+				return;
+			} else if (newNode.priority < current.priority) {
+				// We've found some element with lower priority than the new one, so insert the new one just before it
+				newNode.next = current;
+				if (previous) {
+					previous.next = newNode;
+				} else {
+					this.first = newNode;
+				}
+				inserted = true;
+				previous = current;
+				current = current.next
+				break;
+			}
+			previous = current;
+			current = current.next;
+		}
+
+		if (inserted) {
+			// Go through the rest of the list and try to find an equivalent element to the new one.
+			// We know it has higher priority than the new one, so remove it.
+			while (current) {
+				if (this.equivalencyCheck(current.value, value)) {
+					if (previous) {
+						previous.next = current.next;
+					} else {
+						this.first = current.next
+					}
+					return;
+				}
+				previous = current;
+				current = current.next;
+			}
+		} else {
+			// We reached the end of the queue without finding a lower-priority or existing element, so
+			// insert the new one at the end
+			previous.next = newNode;
+		}
+	}
+
+	hasNext() {
+		return !!this.first;
+	}
+
+	pop() {
+		const first = this.first;
+		this.first = first?.next;
+		return first?.value;
+	}
+}


### PR DESCRIPTION
A few things to improve the pathfinding algorithm:

### `nextNode` Queue
The current algorithm uses a simple array to store the `nextNode` queue, and sorts the array every iteration in (probably) `O(nlog(n))` time.

I've implemented the `UniquePriorityQueue` which, when pushing a node, will always keep itself sorted in priority order. Also on insert, it will look through the queue for a matching node, and the lower-priority instance of the element is discarded. This gives time complexities:
* Push: `O(n)` on the number of existing elements
* Pop: `O(1)`

### Bound to Canvas (fixes #165)
The current algorithm is only bounded by walls and the top and left of the canvas. If you try to move a token to a space there is no path to (e.g. from a room with the door closed to outside that room) and that space touches the right or bottom of the canvas, the algorithm will hang forever as it tries to find a way around off the grid.

I've added bounds to the right and bottom of the canvas as well.

### Maximum Node Caches per Iteration
The slowest part of the pathfinding algorithm is caching the nodes. Trying to cache many as once can cause the entire UI to hang for several seconds. I've introduced a limit on the number of nodes that can be cached in one attempt at finding a path. If this limit is reached, the algorithm will terminate and no path is given.

When we run the algorithm again (e.g. move the mouse a little) more nodes can be cached and eventually a solution will be found.

### Background Caching
To improve on the above, run a background job to cache all the nodes on the map while the system is otherwise idle. Once caching is complete, the algorithm is extremely fast. This tries to be clever and works its way back from the goal, since those are the most-likely required cached nodes.

### Wall Detection
Since the algorithm works backwards, wall calculation was done in the wrong direction, causing directional walls to be calculated the wrong way round. I've swapped the order we pass the walls into the collision function to account for this.

### Levels Compatability
Which walls prevent movement can change depending on the token's height, and so the cache is only necessarily correct until the token changes height. I've added a check so that, if the token is a different height to what it was when we built the cache, we discard it and start again.