### PR TITLE
Pathfinding Improvements: Bound Algorithm to Canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /foundry*.js
 artifact/
 wasm/
+*.lock

--- a/js/main.js
+++ b/js/main.js
@@ -79,7 +79,7 @@ Hooks.on("getCombatTrackerEntryContext", function (html, menu) {
 });
 
 function forwardIfUnahndled(newFn) {
-	return function (oldFn, ...args) {
+	return function(oldFn, ...args) {
 		const eventHandled = newFn(...args);
 		if (!eventHandled)
 			oldFn(...args);

--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,7 @@ import {disableSnap, registerKeybindings} from "./keybindings.js";
 import {libWrapper} from "./libwrapper_shim.js";
 import {performMigrations} from "./migration.js"
 import {removeLastHistoryEntryIfAt, resetMovementHistory} from "./movement_tracking.js";
-import {wipePathfindingCache, initialisePathfinding} from "./pathfinding.js";
+import {wipePathfindingCache, initializePathfinding} from "./pathfinding.js";
 import {extendRuler} from "./ruler.js";
 import {registerSettings, RightClickAction, settingsKey} from "./settings.js"
 import {recalculate} from "./socket.js";
@@ -23,7 +23,7 @@ initGridlessPathfinding().then(() => {
 	Hooks.on("canvasInit", wipePathfindingCache);
 	Hooks.on("canvasReady", () => {
 		wipePathfindingCache();
-		initialisePathfinding();
+		initializePathfinding();
 	});
 	Hooks.on("createWall", wipePathfindingCache);
 	Hooks.on("updateWall", wipePathfindingCache);

--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,7 @@ import {disableSnap, registerKeybindings} from "./keybindings.js";
 import {libWrapper} from "./libwrapper_shim.js";
 import {performMigrations} from "./migration.js"
 import {removeLastHistoryEntryIfAt, resetMovementHistory} from "./movement_tracking.js";
-import {wipePathfindingCache} from "./pathfinding.js";
+import {wipePathfindingCache, initialisePathfinding} from "./pathfinding.js";
 import {extendRuler} from "./ruler.js";
 import {registerSettings, RightClickAction, settingsKey} from "./settings.js"
 import {recalculate} from "./socket.js";
@@ -21,7 +21,10 @@ export let debugGraphics = undefined;
 
 initGridlessPathfinding().then(() => {
 	Hooks.on("canvasInit", wipePathfindingCache);
-	Hooks.on("canvasReady", wipePathfindingCache);
+	Hooks.on("canvasReady", () => {
+		wipePathfindingCache();
+		initialisePathfinding();
+	});
 	Hooks.on("createWall", wipePathfindingCache);
 	Hooks.on("updateWall", wipePathfindingCache);
 	Hooks.on("deleteWall", wipePathfindingCache);
@@ -76,7 +79,7 @@ Hooks.on("getCombatTrackerEntryContext", function (html, menu) {
 });
 
 function forwardIfUnahndled(newFn) {
-	return function(oldFn, ...args) {
+	return function (oldFn, ...args) {
 		const eventHandled = newFn(...args);
 		if (!eventHandled)
 			oldFn(...args);

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -161,7 +161,7 @@ export function wipePathfindingCache() {
 		debugGraphics.removeChildren().forEach(c => c.destroy());
 }
 
-export function initialisePathfinding() {
+export function initializePathfinding() {
 	gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
 	gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
 }

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -9,6 +9,7 @@ import * as GridlessPathfinding from "../wasm/gridless_pathfinding.js"
 let cachedNodes = undefined;
 let use5105 = false;
 let gridlessPathfinders = new Map();
+let gridWidth, gridHeight;
 
 export function isPathfindingEnabled() {
 	if (this.user !== game.user)
@@ -51,17 +52,7 @@ export function findPath(from, to, token, previousWaypoints) {
 	}
 }
 
-export function wipePathfindingCache() {
-	cachedNodes = undefined;
-	for (const pathfinder of gridlessPathfinders.values()) {
-		GridlessPathfinding.free(pathfinder);
-	}
-	gridlessPathfinders.clear();
-	if (debugGraphics)
-		debugGraphics.removeChildren().forEach(c => c.destroy());
-}
-
-function getNode(pos, token, initialize=true) {
+function getNode(pos, token, initialize = true) {
 	pos = {layer: 0, ...pos}; // Copy pos and set pos.layer to the default value if it's unset
 	if (!cachedNodes)
 		cachedNodes = new Array(2);
@@ -77,8 +68,10 @@ function getNode(pos, token, initialize=true) {
 	if (initialize && !node.edges) {
 		node.edges = [];
 		for (const neighborPos of canvas.grid.grid.getNeighbors(pos.y, pos.x).map(([y, x]) => {return {x, y};})) {
-			if (neighborPos.x < 0 || neighborPos.y < 0)
+			if (neighborPos.x < 0 || neighborPos.y < 0 || neighborPos.x > gridWidth || neighborPos.y > gridHeight) {
 				continue;
+			}
+
 			// TODO Work with pixels instead of grid locations
 			if (!stepCollidesWithWall(pos, neighborPos, token)) {
 				const isDiagonal = node.x !== neighborPos.x && node.y !== neighborPos.y && canvas.grid.type === CONST.GRID_TYPES.SQUARE;
@@ -156,6 +149,21 @@ function stepCollidesWithWall(from, to, token) {
 	const stepStart = getSnapPointForTokenObj(getPixelsFromGridPositionObj(from), token);
 	const stepEnd = getSnapPointForTokenObj(getPixelsFromGridPositionObj(to), token);
 	return canvas.walls.checkCollision(new Ray(stepStart, stepEnd));
+}
+
+export function wipePathfindingCache() {
+	cachedNodes = undefined;
+	for (const pathfinder of gridlessPathfinders.values()) {
+		GridlessPathfinding.free(pathfinder);
+	}
+	gridlessPathfinders.clear();
+	if (debugGraphics)
+		debugGraphics.removeChildren().forEach(c => c.destroy());
+}
+
+export function initialisePathfinding() {
+	gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
+	gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
 }
 
 function paintGriddedPathfindingDebug(lastNode, token) {

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -52,7 +52,7 @@ export function findPath(from, to, token, previousWaypoints) {
 	}
 }
 
-function getNode(pos, token, initialize = true) {
+function getNode(pos, token, initialize=true) {
 	pos = {layer: 0, ...pos}; // Copy pos and set pos.layer to the default value if it's unset
 	if (!cachedNodes)
 		cachedNodes = new Array(2);


### PR DESCRIPTION
The current algorithm is only bounded by walls and the top and left of the canvas. If you try to move a token to a space there is no path to (e.g. from a room with the door closed to outside that room) and that space touches the right or bottom of the canvas, the algorithm will hang forever as it tries to find a way around off the grid.

I've added bounds to the right and bottom of the canvas as well. Fixes #165.

This PR also moves the existing caching method, so it isn't in between the methods used by the algorithm.