### PR TITLE
Pathfinding Improvements: Change Search Direction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /foundry*.js
 artifact/
 wasm/
+*.lock

--- a/js/main.js
+++ b/js/main.js
@@ -16,7 +16,7 @@ import {setSnapParameterOnOptions} from "./util.js";
 
 import initGridlessPathfinding, * as GridlessPathfinding from "../wasm/gridless_pathfinding.js"
 
-CONFIG.debug.dragRuler = false;
+CONFIG.debug.dragRuler = true;
 export let debugGraphics = undefined;
 
 initGridlessPathfinding().then(() => {

--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,7 @@ import {disableSnap, registerKeybindings} from "./keybindings.js";
 import {libWrapper} from "./libwrapper_shim.js";
 import {performMigrations} from "./migration.js"
 import {removeLastHistoryEntryIfAt, resetMovementHistory} from "./movement_tracking.js";
-import {wipePathfindingCache} from "./pathfinding.js";
+import {wipePathfindingCache, initialisePathfinding} from "./pathfinding.js";
 import {extendRuler} from "./ruler.js";
 import {registerSettings, RightClickAction, settingsKey} from "./settings.js"
 import {recalculate} from "./socket.js";
@@ -21,7 +21,10 @@ export let debugGraphics = undefined;
 
 initGridlessPathfinding().then(() => {
 	Hooks.on("canvasInit", wipePathfindingCache);
-	Hooks.on("canvasReady", wipePathfindingCache);
+	Hooks.on("canvasReady", () => {
+		wipePathfindingCache();
+		initialisePathfinding();
+	});
 	Hooks.on("createWall", wipePathfindingCache);
 	Hooks.on("updateWall", wipePathfindingCache);
 	Hooks.on("deleteWall", wipePathfindingCache);
@@ -76,7 +79,7 @@ Hooks.on("getCombatTrackerEntryContext", function (html, menu) {
 });
 
 function forwardIfUnahndled(newFn) {
-	return function(oldFn, ...args) {
+	return function (oldFn, ...args) {
 		const eventHandled = newFn(...args);
 		if (!eventHandled)
 			oldFn(...args);

--- a/js/main.js
+++ b/js/main.js
@@ -16,7 +16,7 @@ import {setSnapParameterOnOptions} from "./util.js";
 
 import initGridlessPathfinding, * as GridlessPathfinding from "../wasm/gridless_pathfinding.js"
 
-CONFIG.debug.dragRuler = true;
+CONFIG.debug.dragRuler = false;
 export let debugGraphics = undefined;
 
 initGridlessPathfinding().then(() => {

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -9,6 +9,7 @@ import * as GridlessPathfinding from "../wasm/gridless_pathfinding.js"
 let cachedNodes = undefined;
 let use5105 = false;
 let gridlessPathfinders = new Map();
+let gridWidth, gridHeight;
 
 export function isPathfindingEnabled() {
 	if (this.user !== game.user)
@@ -51,17 +52,7 @@ export function findPath(from, to, token, previousWaypoints) {
 	}
 }
 
-export function wipePathfindingCache() {
-	cachedNodes = undefined;
-	for (const pathfinder of gridlessPathfinders.values()) {
-		GridlessPathfinding.free(pathfinder);
-	}
-	gridlessPathfinders.clear();
-	if (debugGraphics)
-		debugGraphics.removeChildren().forEach(c => c.destroy());
-}
-
-function getNode(pos, token, initialize=true) {
+function getNode(pos, token, initialize = true) {
 	pos = {layer: 0, ...pos}; // Copy pos and set pos.layer to the default value if it's unset
 	if (!cachedNodes)
 		cachedNodes = new Array(2);
@@ -77,8 +68,10 @@ function getNode(pos, token, initialize=true) {
 	if (initialize && !node.edges) {
 		node.edges = [];
 		for (const neighborPos of canvas.grid.grid.getNeighbors(pos.y, pos.x).map(([y, x]) => {return {x, y};})) {
-			if (neighborPos.x < 0 || neighborPos.y < 0)
+			if (neighborPos.x < 0 || neighborPos.y < 0 || neighborPos.x > gridWidth || neighborPos.y > gridHeight) {
 				continue;
+			}
+
 			// TODO Work with pixels instead of grid locations
 			if (!stepCollidesWithWall(pos, neighborPos, token)) {
 				const isDiagonal = node.x !== neighborPos.x && node.y !== neighborPos.y && canvas.grid.type === CONST.GRID_TYPES.SQUARE;
@@ -156,6 +149,21 @@ function stepCollidesWithWall(from, to, token) {
 	const stepStart = getSnapPointForTokenObj(getPixelsFromGridPositionObj(from), token);
 	const stepEnd = getSnapPointForTokenObj(getPixelsFromGridPositionObj(to), token);
 	return canvas.walls.checkCollision(new Ray(stepStart, stepEnd));
+}
+
+export function wipePathfindingCache() {
+	cachedNodes = undefined;
+	for (const pathfinder of gridlessPathfinders.values()) {
+		GridlessPathfinding.free(pathfinder);
+	}
+	gridlessPathfinders.clear();
+	if (debugGraphics)
+		debugGraphics.removeChildren().forEach(c => c.destroy());
+}
+
+export function initialisePathfinding() {
+	gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
+	gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
 }
 
 function paintGriddedPathfindingDebug(lastNode, token) {

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -32,8 +32,7 @@ export function findPath(from, to, token, previousWaypoints) {
 		}
 		paintGridlessPathfindingDebug(pathfinder);
 		return GridlessPathfinding.findPath(pathfinder, from, to);
-	}
-	else {
+	} else {
 		const lastNode = calculatePath(from, to, token, previousWaypoints);
 		if (!lastNode)
 			return null;
@@ -54,18 +53,15 @@ export function findPath(from, to, token, previousWaypoints) {
 }
 
 function getNode(pos, token, initialize = true) {
-	pos = {layer: 0, ...pos}; // Copy pos and set pos.layer to the default value if it's unset
 	if (!cachedNodes)
-		cachedNodes = new Array(2);
-	if (!cachedNodes[pos.layer])
-		cachedNodes[pos.layer] = new Array(Math.ceil(canvas.dimensions.height / canvas.grid.h));
-	if (!cachedNodes[pos.layer][pos.y])
-		cachedNodes[pos.layer][pos.y] = new Array(Math.ceil(canvas.dimensions.width / canvas.grid.w));
-	if (!cachedNodes[pos.layer][pos.y][pos.x]) {
-		cachedNodes[pos.layer][pos.y][pos.x] = pos;
+		cachedNodes = new Array(gridHeight);
+	if (!cachedNodes[pos.y])
+		cachedNodes[pos.y] = new Array(gridWidth);
+	if (!cachedNodes[pos.y][pos.x]) {
+		cachedNodes[pos.y][pos.x] = pos;
 	}
 
-	const node = cachedNodes[pos.layer][pos.y][pos.x];
+	const node = cachedNodes[pos.y][pos.x];
 	if (initialize && !node.edges) {
 		node.edges = [];
 		for (const neighborPos of canvas.grid.grid.getNeighbors(pos.y, pos.x).map(([y, x]) => {return {x, y};})) {
@@ -76,17 +72,11 @@ function getNode(pos, token, initialize = true) {
 			// TODO Work with pixels instead of grid locations
 			if (!stepCollidesWithWall(pos, neighborPos, token)) {
 				const isDiagonal = node.x !== neighborPos.x && node.y !== neighborPos.y && canvas.grid.type === CONST.GRID_TYPES.SQUARE;
-				let targetLayer = pos.layer;
-				if (use5105 && isDiagonal)
-					targetLayer = 1 - targetLayer;
-				const neighbor = getNode({...neighborPos, layer: targetLayer}, token, false);
+				const neighbor = getNode(neighborPos, token, false);
 
-				// TODO We currently assume a cost of one or two for all transitions. Change this for difficult terrain support
-				let edgeCost = 1;
-				if (isDiagonal) {
-					// We charge 0.0001 more for edges to avoid unnecessary diagonal steps
-					edgeCost = pos.layer === 1 && targetLayer === 0 ? 2 : 1.0001;
-				}
+				// Count 5-10-5 diagonals as 1.5 (so two add up to 3) and 5-5-5 diagonals as 1.0001 (to discourage unnecessary diagonals)
+				// TODO Account for difficult terrain
+				let edgeCost = isDiagonal ? (use5105 ? 1.5 : 1.0001) : 1;
 				node.edges.push({target: neighbor, cost: edgeCost});
 			}
 		}
@@ -95,14 +85,11 @@ function getNode(pos, token, initialize = true) {
 }
 
 function calculatePath(from, to, token, previousWaypoints) {
-	if (game.system.id === "pf2e")
-		use5105 = true;
-	if (canvas.grid.diagonalRule === "5105")
-		use5105 = true;
-	let startLayer = 0;
+	use5105 = game.system.id === "pf2e" || canvas.grid.diagonalRule === "5105";
+	let startCost = 0;
 	if (use5105 && canvas.grid.type === CONST.GRID_TYPES.SQUARE) {
 		previousWaypoints = previousWaypoints.map(w => getGridPositionFromPixelsObj(w));
-		startLayer = calcNoDiagonals(previousWaypoints) % 2;
+		startCost = (calcNoDiagonals(previousWaypoints) % 2) * 0.5;
 	}
 
 	const nextNodes = new UniquePriorityQueue((node1, node2) => node1.node === node2.node);
@@ -110,9 +97,9 @@ function calculatePath(from, to, token, previousWaypoints) {
 
 	nextNodes.push(
 		{
-			node: getNode({...to, layer: startLayer}, token),
-			cost: 0,
-			estimated: estimateCost(to, from),
+			node: getNode(to, token),
+			cost: startCost,
+			estimated: startCost + estimateCost(to, from),
 			previous: null
 		}
 	);
@@ -149,8 +136,14 @@ function calcNoDiagonals(waypoints) {
 	return diagonals;
 }
 
+/**
+ * Estimate the travel distance between two points, as the crow flies. Most of the time, this is 1
+ * per space, but for a square grid using 5-10-5 diagonals, count each diagonal as an extra 0.5
+ */
 function estimateCost(pos, target) {
-	return Math.max(Math.abs(pos.x - target.x), Math.abs(pos.y - target.y));
+	const distX = Math.abs(pos.x - target.x);
+	const distY = Math.abs(pos.y - target.y);
+	return Math.max(distX, distY) + (use5105 ? Math.min(distX, distY) * 0.5 : 0);
 }
 
 function stepCollidesWithWall(from, to, token) {

--- a/js/queues.js
+++ b/js/queues.js
@@ -1,0 +1,80 @@
+/**
+ * An ordered queue where all the elements are unique, according to the equivalencyCheck.
+ * On insert, the element will only be added if there is not already a higher-priority equivalent element in the queue.
+ * If there is a lower-priority equivalent element in the queue, it will be removed.
+ */
+ export class UniquePriorityQueue {
+	constructor(elementMatcher) {
+		this.first = null;
+		this.elementMatcher = elementMatcher;
+	}
+
+	push(value, priority) {
+		const newNode = { value, priority, next: null };
+
+		// If the queue is currently empty, we can just set this new node as the first and we're done
+		if (!this.first) {
+			this.first = newNode;
+			return;
+		}
+
+		let inserted = false;
+		let previous;
+		let current = this.first;
+
+		// Loop through the existing elements
+		while (current) {
+			if (this.elementMatcher(current.value, value)) {
+				// We've found an equivalent element before one with a lower priority. This one has at least
+				// the same priority as the new one, so don't bother inserting
+				return;
+			} else if (newNode.priority < current.priority) {
+				// We've found some element with lower priority than the new one, so insert the new one just before it
+				newNode.next = current;
+				if (previous) {
+					previous.next = newNode;
+				} else {
+					this.first = newNode;
+				}
+				inserted = true;
+				
+                previous = current;
+				current = current.next
+				break;
+			}
+			previous = current;
+			current = current.next;
+		}
+
+		if (inserted) {
+			// Go through the rest of the list and try to find an equivalent element to the new one.
+			// We know it has higher priority than the new one, so remove it.
+			while (current) {
+				if (this.elementMatcher(current.value, value)) {
+					if (previous) {
+						previous.next = current.next;
+					} else {
+						this.first = current.next
+					}
+					return;
+				}
+				previous = current;
+				current = current.next;
+			}
+		} else {
+			// We reached the end of the queue without finding a lower-priority or existing element, so
+			// insert the new one at the end
+			previous.next = newNode;
+		}
+	}
+
+	hasNext() {
+		return !!this.first;
+	}
+
+	pop() {
+		const first = this.first;
+		this.first = first?.next;
+		return first?.value;
+	}
+}

--- a/js/queues.js
+++ b/js/queues.js
@@ -1,4 +1,36 @@
 /**
+ * Simple LIFO stack that tracks which element
+ */
+export class RetraversableStack {
+	constructor() {
+		this.top = null;
+		this.next = null;
+	}
+
+	push(value) {
+		const newNode = {value, next: this.top};
+		if (!this.top) {
+			this.next = newNode;
+		}
+		this.top = newNode;
+	}
+
+	getNext() {
+		const next = this.next?.value
+		this.next = this.next?.next;
+		return next;
+	}
+
+	hasNext() {
+		return !!this.next;
+	}
+
+	reset() {
+		this.next = this.top;
+	}
+}
+
+/**
  * An ordered queue where all the elements are unique, according to the equivalencyCheck.
  * On insert, the element will only be added if there is not already a higher-priority equivalent element in the queue.
  * If there is a lower-priority equivalent element in the queue, it will be removed.
@@ -9,8 +41,8 @@
 		this.elementMatcher = elementMatcher;
 	}
 
-	push(value, priority) {
-		const newNode = { value, priority, next: null };
+	push(value, priority, tiePriority) {
+		const newNode = { value, priority, tiePriority, next: null };
 
 		// If the queue is currently empty, we can just set this new node as the first and we're done
 		if (!this.first) {
@@ -28,7 +60,7 @@
 				// We've found an equivalent element before one with a lower priority. This one has at least
 				// the same priority as the new one, so don't bother inserting
 				return;
-			} else if (newNode.priority < current.priority) {
+			} else if (newNode.priority < current.priority || (newNode.priority === current.priority && newNode.tiePriority < current.tiePriority)) {
 				// We've found some element with lower priority than the new one, so insert the new one just before it
 				newNode.next = current;
 				if (previous) {


### PR DESCRIPTION
Change pathfinding to start from the token and work its way to the target rather than the other way round. This means spaces near the token will be cached first, which is more useful than the spaces near the target being cached first, if the target changes significantly.

This also lays some groundwork for future improvements to the algorithm.

**Note: ** waiting for #170 to be merged.