### PR TITLE
Levels Compatibility: Clear pathfinding cache after changing elevation

### DIFF
--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -8,6 +8,7 @@ import * as GridlessPathfinding from "../wasm/gridless_pathfinding.js"
 import {PriorityQueueSet} from "./data_structures.js";
 
 let cachedNodes = undefined;
+let cacheElevation;
 let use5105 = false;
 let gridlessPathfinders = new Map();
 let gridWidth, gridHeight;
@@ -23,6 +24,8 @@ export function isPathfindingEnabled() {
 }
 
 export function findPath(from, to, token, previousWaypoints) {
+	checkCacheValid(token);
+	
 	if (canvas.grid.type === CONST.GRID_TYPES.GRIDLESS) {
 		let tokenSize = Math.max(token.data.width, token.data.height) * canvas.dimensions.size;
 		let pathfinder = gridlessPathfinders.get(tokenSize);
@@ -202,4 +205,18 @@ function paintGridlessPathfindingDebug(pathfinder) {
 		graphic.drawCircle(point.x, point.y, 5);
 	}
 	debugGraphics.addChild(graphic);
+}
+
+/**
+ * Check if the current cache is still suitable for the path we're about to find. If not, clear the cache
+ */
+function checkCacheValid(token) {
+	// If levels is enabled, the cache is invalid if it was made for a 
+	if (game.modules.get("levels")?.active) {
+		const tokenElevation = token.data.elevation;
+		if (tokenElevation !== cacheElevation) {
+			cacheElevation = tokenElevation;
+			wipePathfindingCache();
+		}
+	}
 }

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -172,6 +172,20 @@ export function wipePathfindingCache() {
 		debugGraphics.removeChildren().forEach(c => c.destroy());
 }
 
+/**
+ * Check if the current cache is still suitable for the path we're about to find. If not, clear the cache
+ */
+ function checkCacheValid(token) {
+	// If levels is enabled, the cache is invalid if it was made for a 
+	if (game.modules.get("levels")?.active) {
+		const tokenElevation = token.data.elevation;
+		if (tokenElevation !== cacheElevation) {
+			cacheElevation = tokenElevation;
+			wipePathfindingCache();
+		}
+	}
+}
+
 export function initializePathfinding() {
 	gridWidth = Math.ceil(canvas.dimensions.width / canvas.grid.w);
 	gridHeight = Math.ceil(canvas.dimensions.height / canvas.grid.h);
@@ -205,18 +219,4 @@ function paintGridlessPathfindingDebug(pathfinder) {
 		graphic.drawCircle(point.x, point.y, 5);
 	}
 	debugGraphics.addChild(graphic);
-}
-
-/**
- * Check if the current cache is still suitable for the path we're about to find. If not, clear the cache
- */
-function checkCacheValid(token) {
-	// If levels is enabled, the cache is invalid if it was made for a 
-	if (game.modules.get("levels")?.active) {
-		const tokenElevation = token.data.elevation;
-		if (tokenElevation !== cacheElevation) {
-			cacheElevation = tokenElevation;
-			wipePathfindingCache();
-		}
-	}
 }


### PR DESCRIPTION
If the Levels module is enabled, then keep track of what elevation the cache was made for. If we start pathfinding for a different height, then the walls we need to worry about may have changed, so clear the cache and start again.