### PR TITLE
Improve Pathfinding: Background Caching

### DIFF
--- a/js/data_structures.js
+++ b/js/data_structures.js
@@ -80,3 +80,49 @@ export class PriorityQueueSet {
 		return first?.value;
 	}
 }
+
+/**
+ * Queue that will only ever accept a single value once
+ */
+ export class ProcessOnceQueue {
+	constructor() {
+		this.first = null;
+		this.last = null;
+		this.queued = new Set();
+	}
+
+	push(value) {
+		if (this.queued.has(value)) {
+			return;
+		}
+		this.queued.add(value);
+
+		const newNode = {
+			value,
+			next: null,
+			previous: null
+		}
+
+		if (!this.first) {
+			this.first = newNode;
+			this.last = newNode;
+		} else {
+			this.last.next = newNode;
+			newNode.previous = this.last;
+			this.last = newNode;
+		}
+	}
+
+	pop() {
+		const node = this.first;
+		this.first = node?.next;
+		if (!node.next) {
+			this.last = null;
+		}
+		return node.value;
+	}
+
+	hasNext() {
+		return !!this.first;
+	}
+}

--- a/js/data_structures.js
+++ b/js/data_structures.js
@@ -91,6 +91,12 @@ export class PriorityQueueSet {
 		this.queued = new Set();
 	}
 
+	reset() {
+		this.first = null;
+		this.last = null;
+		this.queued.clear();
+	}
+
 	push(value) {
 		if (this.queued.has(value)) {
 			return;
@@ -116,10 +122,10 @@ export class PriorityQueueSet {
 	pop() {
 		const node = this.first;
 		this.first = node?.next;
-		if (!node.next) {
+		if (!node?.next) {
 			this.last = null;
 		}
-		return node.value;
+		return node?.value;
 	}
 
 	hasNext() {

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -7,7 +7,11 @@ import {getSnapPointForTokenObj, iterPairs} from "./util.js";
 import * as GridlessPathfinding from "../wasm/gridless_pathfinding.js"
 import {PriorityQueueSet} from "./data_structures.js";
 
-let cachedNodes = undefined;
+const cache = {
+	nodes: null,
+	elevation: null
+};
+
 let use5105 = false;
 let gridlessPathfinders = new Map();
 let gridWidth, gridHeight;


### PR DESCRIPTION
Caching nodes can be the slowest part of the pathfinding algorithm, so we should do as much of this as possible before the information is needed.

When we start pathfinding, we launch a background task. This task starts caching at the current token's position, and works its way out to that node's adjacent nodes, and then those nodes' adjacent nodes etc.

For the best results, we want to start pathfinding from the same place we build our cache - that way we're most likely to already have some nodes cached along the path and reduce the total time to complete the path. To that end, I've changed the algorithm to work from the token to the target rather than the other way around. We then create a linked list of nodes from the start of the path to the end, so the node returned from `calculatePath` is still the start of the path.