### PR TITLE
Add the pathfinding radius setting

### DIFF
--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -237,7 +237,8 @@ export function isPathfindingEnabled() {
 
 export function findPath(from, to, token, previousWaypoints) {
 	if (canvas.grid.type === CONST.GRID_TYPES.GRIDLESS) {
-		let tokenSize = Math.max(token.data.width, token.data.height) * canvas.dimensions.size;
+		let radiusMultiplier = game.settings.get(settingsKey, "pathfindingRadius");
+		let tokenSize = Math.max(token.data.width, token.data.height) * canvas.dimensions.size * radiusMultiplier;
 		let pathfinder = gridlessPathfinders.get(tokenSize);
 		if (!pathfinder) {
 			pathfinder = GridlessPathfinding.initialize(canvas.walls.placeables, tokenSize, token.data.elevation, Boolean(game.modules.get("wall-height")?.active));

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -237,11 +237,11 @@ export function isPathfindingEnabled() {
 
 export function findPath(from, to, token, previousWaypoints) {
 	if (canvas.grid.type === CONST.GRID_TYPES.GRIDLESS) {
-		let radiusMultiplier = game.settings.get(settingsKey, "pathfindingRadius");
-		let tokenSize = Math.max(token.data.width, token.data.height) * canvas.dimensions.size * radiusMultiplier;
+		let tokenSize = Math.max(token.data.width, token.data.height) * canvas.dimensions.size;
 		let pathfinder = gridlessPathfinders.get(tokenSize);
 		if (!pathfinder) {
-			pathfinder = GridlessPathfinding.initialize(canvas.walls.placeables, tokenSize, token.data.elevation, Boolean(game.modules.get("wall-height")?.active));
+			let radiusMultiplier = game.settings.get(settingsKey, "pathfindingRadius");
+			pathfinder = GridlessPathfinding.initialize(canvas.walls.placeables, tokenSize * radiusMultiplier, token.data.elevation, Boolean(game.modules.get("wall-height")?.active));
 			gridlessPathfinders.set(tokenSize, pathfinder);
 		}
 		paintGridlessPathfindingDebug(pathfinder);

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,5 +1,6 @@
 import {availableSpeedProviders, currentSpeedProvider, getDefaultSpeedProvider, updateSpeedProvider} from "./api.js";
 import {SpeedProvider} from "./speed_provider.js"
+import {wipePathfindingCache} from "./pathfinding.js"
 import { early_isGM } from "./util.js";
 
 export const settingsKey = "drag-ruler";
@@ -111,6 +112,7 @@ export function registerSettings() {
 		config: false,
 		type: Number,
 		default: 0.9,
+		onChange: wipePathfindingCache,
 	});
 
 	game.settings.register(settingsKey, "lastTerrainRulerHintTime", {

--- a/js/settings.js
+++ b/js/settings.js
@@ -100,10 +100,17 @@ export function registerSettings() {
 	game.settings.register(settingsKey, "autoPathfinding", {
 		name: "drag-ruler.settings.autoPathfinding.name",
 		hint: "drag-ruler.settings.autoPathfinding.hint",
-		scpoe: "client",
+		scope: "client",
 		config: early_isGM() || game.settings.get(settingsKey, "allowPathfinding"),
 		type: Boolean,
-		defualt: false,
+		default: false,
+	});
+
+	game.settings.register(settingsKey, "pathfindingRadius", {
+		scope: "world",
+		config: false,
+		type: Number,
+		default: 0.9,
 	});
 
 	game.settings.register(settingsKey, "lastTerrainRulerHintTime", {


### PR DESCRIPTION
Resolves #193 

This setting is used when doing gridless pathfinding to determine how close a token can pathfind to a wall, relative to the token's size.

I also fixed a few typos in the config for "autoPathfinding" ("scpoe" and "defualt"). Hope you don't mind