### PR TITLE
add splittermond with speed and dash multiplier

### DIFF
--- a/js/systems.js
+++ b/js/systems.js
@@ -21,6 +21,8 @@ export function getDefaultSpeedAttribute() {
 			return "actor.data.data.stats.speed.adjusted";
 		case "ds4":
 			return "actor.data.data.combatValues.movement.total";
+		case "splittermond":
+			return "actor.derivedValues.speed.value";
 	}
 	return ""
 }
@@ -41,6 +43,8 @@ export function getDefaultDashMultiplier() {
 			return 2;
 		case "CoC7":
 			return 5;
+		case "splittermond":
+			return 3;
 	}
 	return 0;
 }


### PR DESCRIPTION
I had a hard time finding these values and so I thought I should share it with others.

Splittermond ist a german RPG without an english translation as of now.
It has an english description though: https://foundryvtt.com/packages/splittermond

The values aren't fixed and the system itself calculates it based on certain factors like wounds, health, modifiers, so it should work really well.