### PR TITLE
Update lancer speed attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The game systems that offer Drag Ruler integration are:
 - GURPS 4th Edition Game Aid (Unofficial) (starting with version 0.9.1)
 - Hackmaster (starting with version 0.2.11)
 - Ironclaw Second Edition (starting with version 0.2.2)
-- Lancer (via the module [Lancer Speed Provider](https://foundryvtt.com/packages/lancer-speed-provider))
+- Lancer (via the module [Lancer Ruler Integration](https://foundryvtt.com/packages/lancer-speed-provider))
 - Level Up: Advanced 5th Edition (Official) (via the module [A5E Drag Ruler Integration](https://foundryvtt.com/packages/a5edragruler))
 - Pathfinder 1 (starting with version 0.77.3)
 - Pathfinder 2e (via the module [PF2E Drag Ruler Integration](https://foundryvtt.com/packages/pf2e-dragruler/))

--- a/src/systems.js
+++ b/src/systems.js
@@ -9,7 +9,7 @@ export function getDefaultSpeedAttribute() {
 		case "dnd5e":
 			return "actor.system.attributes.movement.walk";
 		case "lancer":
-			return "actor.system.derived.speed";
+			return "actor.system.speed";
 		case "pf1":
 		case "D35E":
 			return "actor.system.attributes.speed.land.total";


### PR DESCRIPTION
The pending 2.0.0 release has a different path. The current version of lancer is v10 only and the next release will be v11 only, so the change won't affect any current users.