### PR TITLE
Improve Walled Templates compatibility

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -133,6 +133,7 @@ async function tokenLayerUndoHistory(wrapped) {
 
 function onEntityLeftDragStart(wrapped, event) {
 	wrapped(event);
+        if ( this.attachedToken ) return; // (Walled Templates) template has attached token.
 	const isToken = this instanceof Token;
 	const ruler = canvas.controls.ruler;
 	ruler.draggedEntity = this;
@@ -155,6 +156,7 @@ function onEntityLeftDragMoveSnap(wrapped, event) {
 
 function onEntityLeftDragMove(wrapped, event) {
 	wrapped(event);
+        if ( this.attachedToken ) return; // (Walled Templates) template has attached token.
 	const ruler = canvas.controls.ruler;
 	if (ruler.isDragRuler) onMouseMove.call(ruler, event);
 }


### PR DESCRIPTION
Walled Templates has a feature to allow a template to be "attached," or "linked" to a token. When attached, a template moves in-sync with a token. Thus, Drag Ruler should move the token but ignore the template when it is attached.

Addresses Drag Ruler issue #297.