### PR TITLE
adding ability to change ruler width on gridless scenes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -115,6 +115,14 @@
 			"useGridlessRaster": {
 				"name": "Use speed based snapping",
 				"hint": "On Gridless scenes, this makes tokens snap to the token's speed ranges."
+			},
+			"gridlessRulerWidth": {
+				"name": "Ruler Width",
+				"hint": "Set width of Drag Ruler on Gridless scenes"
+			},
+			"gridlessRulerBorderWidth": {
+				"name": "Ruler Border Width",
+				"hint": "Set width of Drag Ruler border on Gridless scenes"
 			}
 		}
 	}

--- a/src/ruler.js
+++ b/src/ruler.js
@@ -293,9 +293,15 @@ export function extendRuler() {
 				return super._drawMeasuredPath();
 			}
 			let rulerColor = this.color;
+			let rulerWidth = 4;
+			let rulerBorderWidth = 2;
+
+
 			if (!this.dragRulerGridSpaces || canvas.grid.type === CONST.GRID_TYPES.GRIDLESS) {
 				const totalDistance = this.segments.reduce((total, current) => total + current.distance, 0);
 				rulerColor = this.dragRulerGetColorForDistance(totalDistance);
+				rulerWidth = game.settings.get(settingsKey, "rulerWidth");
+				rulerBorderWidth = game.settings.get(settingsKey, "rulerBorderWidth");
 			}
 			const r = this.ruler.beginFill(rulerColor, 0.25);
 			for (const segment of this.dragRulerUnsnappedSegments) {
@@ -305,9 +311,9 @@ export function extendRuler() {
 
 				// Draw Line
 				r.moveTo(ray.A.x, ray.A.y)
-					.lineStyle(6, 0x000000, 0.5 * opacityMultiplier)
+					.lineStyle(rulerWidth + rulerBorderWidth, 0x000000, 0.5 * opacityMultiplier)
 					.lineTo(ray.B.x, ray.B.y)
-					.lineStyle(4, rulerColor, 0.25 * opacityMultiplier)
+					.lineStyle(rulerWidth, rulerColor, 0.25 * opacityMultiplier)
 					.moveTo(ray.A.x, ray.A.y)
 					.lineTo(ray.B.x, ray.B.y);
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -142,6 +142,24 @@ export function registerSettings() {
 		type: SpeedProviderSettings,
 		restricted: false,
 	});
+
+	game.settings.register(settingsKey, "rulerWidth", {
+		name: "drag-ruler.settings.gridlessRulerWidth.name",
+		hint: "drag-ruler.settings.gridlessRulerWidth.hint",
+		scope: "client",
+		config: true,
+		type: Number,
+		default: 4,
+	});
+
+	game.settings.register(settingsKey, "rulerBorderWidth", {
+		name: "drag-ruler.settings.gridlessRulerBorderWidth.name",
+		hint: "drag-ruler.settings.gridlessRulerBorderWidth.hint",
+		scope: "client",
+		config: true,
+		type: Number,
+		default: 2,
+	});
 }
 
 class SpeedProviderSettings extends FormApplication {


### PR DESCRIPTION
Implementing enhancement request #26 

Added two new settings to set the ruler and border widths respectively. These width values are only used on gridless scenes and do not change the size of the ruler when the grid is enabled