### PR TITLE
Terrain Mapper compatibility

### DIFF
--- a/src/ruler.js
+++ b/src/ruler.js
@@ -456,11 +456,19 @@ export function extendRuler() {
 				)
 					return this.color;
 			}
+
+		        const points = this.segments.map(s => {
+			  return {
+		            A: new PIXI.Point(s.ray.A.x, s.ray.A.y),
+			    B: new PIXI.Point(s.ray.B.x, s.ray.B.y)
+			  };
+		        });
+
 			distance = Math.round(distance * 100) / 100;
 			if (!this.dragRulerRanges)
 				this.dragRulerRanges = getRangesFromSpeedProvider(this.draggedEntity);
 			return (
-				getColorForDistanceAndToken(distance, this.draggedEntity, this.dragRulerRanges) ??
+				getColorForDistanceAndToken(distance, this.draggedEntity, this.dragRulerRanges, points) ??
 				this.color
 			);
 		}


### PR DESCRIPTION
Terrain Mapper is a new module that lets the GM label the canvas with terrains. Each terrain can apply active effects to the token. This PR adds a check, relying on the Terrain Mapper API, to recalculate the distance based on whether each ruler segment will cross terrains. 

Essentially, if the segment path hits a terrain that affects the token actor's movement attribute, the bonus/penalty is calculated for the affected portion of the segment. The total distance, for purposes of determining Drag Ruler color, is then adjusted based on this bonus/penalty.