### PR TITLE
Add Support for 5x5 Hex Tokens

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -212,6 +212,16 @@ export function getTokenShape(token) {
 				{x: 0, y: -2},
 				{x: 1, y: -2},
 			]);
+		if (size >= 5)
+			shape = shape.concat([
+				{x: -2, y: 0},
+				{x: 1, y: 1},
+				{x: -1, y: 2},
+				{x: 0, y: 2},
+				{x: 1, y: 2},
+				{x: -2, y: 1},
+				{x: 2, y: 0},
+			]);
 
 		if (getAltOrientationFlagForToken(token, size)) {
 			shape.forEach(space => (space.y *= -1));


### PR DESCRIPTION
This pull request adds support for rendering hex tokens of a default grid size of 5x5. While FoundryVTT does not support them natively yet, some systems make use of 5x5 tokens already, so this allows them to have their tokens properly fill out all hex spaces when being moved.

![image](https://github.com/manuelVo/foundryvtt-drag-ruler/assets/6625966/44db5636-fc6f-49f5-92e0-31ee56a44292)
