### PR TITLE
Fix check to enable/disable Terrain Ruler coloring/distance

### DIFF
--- a/src/ruler.js
+++ b/src/ruler.js
@@ -101,7 +101,7 @@ export function extendRuler() {
 				options.snap = false;
 			}
 			this.dragRulerSnap = options.snap ?? !disableSnap;
-			this.dragRulerEnableTerrainRuler = isToken && window.terrainRuler;
+			this.dragRulerEnableTerrainRuler = isToken && window.terrainRuler && window.terrainRuler.active;
 
 			// Compute the measurement destination, segments, and distance
 			const d = this._getMeasurementDestination(destination);


### PR DESCRIPTION
Barely worth a PR.

`window.terrainRuler` is truthy if it exists, but it should check `window.terrainRuler.active` to make sure we actually want it on anyway. The check to make sure the variable exists in the first place is probably redundant but I'm being paranoid.

This does have the minor effect of a "desync", where the colors/distance traveled are client-side based on whether the client user has terrain ruler enabled, so they might see something different from the dragger, but that's minimal.