### PR TITLE
Fix for label not always showing + distance calculation wrong for diagonals

### DIFF
--- a/src/compatibility.js
+++ b/src/compatibility.js
@@ -44,7 +44,19 @@ export function measureDistances(segments, entity, shape, options = {}) {
 		if (!opts.ignoreGrid) {
 			opts.gridSpaces = true;
 		}
-		return canvas.grid.measureDistances(segments, opts);
+
+		if(segments.length === 0) return [];
+
+		// canvas.grid.measureDistances returns a wrong distance for diagonals in v12
+		// measurePath wants waypoints instead of segments - therefore, we just separate the rays into
+		// waypoints (assuming each ray ends where the next one starts)
+		const waypoints = [ segments[0].ray.A ];
+		for(const segment of segments) {
+			waypoints.push(segment.ray.B);
+		}
+
+		const measure = canvas.grid.measurePath(waypoints);
+		return measure.segments.map(s => s.distance);
 	}
 }
 

--- a/src/foundry_imports.js
+++ b/src/foundry_imports.js
@@ -3,6 +3,7 @@ import {disableSnap, moveWithoutAnimation} from "./keybindings.js";
 import {trackRays} from "./movement_tracking.js";
 import {recalculate} from "./socket.js";
 import {getSnapPointForToken, highlightTokenShape, sum} from "./util.js";
+import {measureDistances} from "./compatibility.js";
 
 // This is a modified version of Ruler.moveToken from foundry 0.7.9
 export async function moveEntities(draggedEntity, selectedEntities) {
@@ -193,7 +194,7 @@ export function highlightMeasurementNative(
 		const point = canvas.grid.getTopLeftPoint(offset);
 		const center = canvas.grid.getCenterPoint(offset);
 		const pathUntilSpace = previousSegments.concat([{ray: new Ray(ray.A, center)}]);
-		const distance = sum(canvas.grid.measureDistances(pathUntilSpace, {gridSpaces: true}));
+		const distance = sum(measureDistances(pathUntilSpace, {gridSpaces: true}));
 		const color = this.dragRulerGetColorForDistance(distance);
 		const snapPoint = getSnapPointForToken(point.x + 1, point.y + 1, this.draggedEntity);
 		const [snapX, snapY] = getGridPositionFromPixels(snapPoint.x + 1, snapPoint.y + 1);

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import {
 	registerModule,
 	registerSystem,
 } from "./api.js";
-import {checkDependencies} from "./compatibility.js";
+import {checkDependencies, measureDistances} from "./compatibility.js";
 import {moveEntities, onMouseMove} from "./foundry_imports.js";
 import {disableSnap, registerKeybindings} from "./keybindings.js";
 import {libWrapper} from "./libwrapper_shim.js";
@@ -251,7 +251,7 @@ function applyGridlessSnapping(event) {
 					return {ray};
 				});
 			origin = segments.pop().ray.A;
-			waypointDistance = canvas.grid.measureDistances(segments).reduce((a, b) => a + b);
+			waypointDistance = measureDistances(segments).reduce((a, b) => a + b);
 			origin = {x: origin.x, y: origin.y};
 		}
 

--- a/src/ruler.js
+++ b/src/ruler.js
@@ -265,9 +265,6 @@ export function extendRuler() {
 					unsnappedSegments.push({ray: unsnappedRay, label});
 				}
 				this.dragRulerUnsnappedSegments = unsnappedSegments;
-				if (this.labels.children.length > segments.length) {
-					this.labels.removeChildren(segments.length).forEach(c => c.destroy());
-				}
 				return segments;
 			} else {
 				return super._getMeasurementSegments();

--- a/src/util.js
+++ b/src/util.js
@@ -88,7 +88,7 @@ export function getSnapPointForToken(x, y, token) {
 		return {x: snapX, y: snapY};
 	}
 
-	const [topLeftX, topLeftY] = canvas.grid.getTopLeft(x, y);
+	const {x: topLeftX, y: topLeftY} = canvas.grid.getTopLeftPoint({x, y});
 	let cell = {};
 	if (token.document.width % 2 === 0) cell.x = x - canvas.grid.sizeY / 2;
 	else cell.x = x;
@@ -142,12 +142,12 @@ export function getSnapPointForEntity(x, y, entity) {
 }
 
 export function highlightTokenShape(position, shape, color, alpha) {
-	const layer = canvas.grid.highlightLayers[this.name];
+	const layer = canvas.interface.grid.highlightLayers[this.name];
 	if (!layer) return false;
 	const area = getAreaFromPositionAndShape(position, shape);
 	for (const space of area) {
 		const [x, y] = getPixelsFromGridPosition(space.x, space.y);
-		canvas.grid.highlightGridPosition(layer, {x, y, color, alpha: 0.25 * alpha});
+		canvas.interface.grid.highlightPosition(layer.name, {x, y, color, alpha: 0.25 * alpha});
 	}
 }
 


### PR DESCRIPTION
This PR fixes two issues:

* #337 
I simply removed the
```
if (this.labels.children.length > segments.length) {
  this.labels.removeChildren(segments.length).forEach(c => c.destroy());
}
```
from ruler.js that was added by @TPNils in #329 . There was no explanation why this is needed - and removing it fixes the problem of the label disappearing with not apparent side effects.

* #342 
`canvas.grid.measureDistances` seems to return a wrong distance for diagonals in Foundry v12. There is a deprecation warning suggesting to use `canvas.grid.measurePath` instead, so I rewrote it to this. This fixes the problem - though the options are no longer relevant and I didn't test gridless stuff etc. because it's not needed for our game.

Additionally, I've updated some calls so that no more deprecation warnings get printed when dragging the ruler (except when routinglib is active).

If you need some small adjustments, just tell me - but overall the Foundry development experiment with the de-facto non-existing developer documentation didn't really encourage me to do more testing than "this works in exactly my case and that's good enough for me".